### PR TITLE
fix(libvirt): harden failure observability

### DIFF
--- a/docs/decisions/issue-1173-run-316-libvirt-failure-observability-preflight.md
+++ b/docs/decisions/issue-1173-run-316-libvirt-failure-observability-preflight.md
@@ -1,0 +1,123 @@
+# Issue 1173 RUN-316 Libvirt Failure Observability Preflight
+
+Date: 2026-09-03
+
+Issue: #1173.
+
+Requirement: RUN-316.
+
+This note narrows the existing RUN-316 guidance to backend failures deliberately
+collapsed by the libvirt adapters. It is design guidance only; it adds no
+runtime behavior, public contract, configuration, persistence, or evidence.
+
+## Binding Boundaries
+
+- ADR-066 and the issue #338 preflight own observability-plane separation.
+  Backend failure records are operator-side apparatus telemetry, not scenario
+  observations, experiment evidence, or derived analysis.
+- `raes_backend_libvirt.drivers.libvirt._native` remains the single authority
+  for libvirt exception identity, native error codes, expected absence, and
+  stop/lookup semantics. `raes_backend_libvirt._observability` may format a safe
+  record; it must not become a second native-error classifier.
+- Existing portable outcomes remain authoritative: `Diagnostic`, `Severity`,
+  `DriverResult`, `ApplyResult`, and runtime/control-plane error envelopes.
+  Operator logging must not change success, failure, retry, rollback, ownership,
+  or fail-closed teardown behavior.
+- Use the existing `raes_backend_libvirt` logger and
+  `record_suppressed_failure()`. Add no handler, global logging configuration,
+  telemetry registry, exception hierarchy, DTO, schema, or store.
+
+## Failure Classification Guardrails
+
+- Every broad catch has exactly one semantic disposition: propagate; recognize
+  a proven expected condition and remain silent; or intentionally collapse a
+  non-benign failure and emit bounded classification before discarding it.
+  Cleanup catches that re-raise, including atomic filesystem cleanup, are not
+  suppressed failures and must not be logged as though they were.
+- Expected native absence requires both the native exception family and an
+  operation-appropriate libvirt code. Duck typing on `get_error_code()` alone
+  is insufficient: an unrelated exception exposing that method remains a real
+  failure and must not change control flow into an absence/no-op success.
+- The existing explicit `KeyError` convention in injected TechVault lookup
+  adapters is a narrow absence sentinel at those named lookup seams. It is not
+  a package-wide native-error rule and must not make arbitrary `KeyError`
+  failures silent elsewhere.
+- Reuse the native code vocabulary and predicates owned by `_native`; do not
+  repeat numeric absence/operation-invalid literals or create a parallel
+  classifier in TechVault or observability modules. Tolerated-code sets remain
+  operation-specific so absence, already-inactive teardown, permission failure,
+  connection failure, and internal failure cannot collapse into one category.
+- The observability path is non-interfering. Classification and formatting must
+  be total for arbitrary caught exceptions and must not raise, call exception
+  stringification, or replace the portable diagnostic/control-flow outcome.
+
+## Bounded Record Contract
+
+A suppressed-failure record may contain only a fixed internal operation token
+and bounded allowlisted scalar classification already supported by
+`record_suppressed_failure()`: a sanitized exception type token, an integer OS
+`errno`, and an integer native code when safely classified. Operation tokens
+must remain code-owned constants, never resource names, addresses, paths, or
+caller-supplied text.
+
+Never record exception messages, `repr`, `args`, causes or contexts, tracebacks
+or `exc_info`, connection URIs, XML, SDL or plan payloads, environment values,
+host paths, subprocess output, native object representations, credentials,
+keys, tokens, prompts, hidden truth, or captured evidence. Keep each record
+bounded independently of exception or payload size, and keep the library silent
+unless the embedding application configures its logger.
+
+## Cross-Cutting Layers
+
+- **Authentication/authorization:** this is an internal backend logging seam,
+  not a new API. It adds no authorization shortcut. Any future reader or export
+  must use `create_control_plane_app()`, `ControlPlaneSecurityConfig`, target
+  binding, the existing `BACKEND`/`OPERATOR`/`AUDITOR` read-role gates, auditing,
+  and bounded response models.
+- **Secrets and redaction:** the allowlist above is the redaction boundary.
+  Exception text and native payloads must not enter logs first and be scrubbed
+  later. Existing value-free libvirt diagnostics remain unchanged.
+- **Configuration and shape validation:** do not add environment binding or a
+  second logger/libvirt config shape. Target construction continues through
+  `target._CONFIG_KEYS`, `_validate_config_keys()`, `_driver_config()`,
+  `LibvirtDriverMode`, manifest/envelope pairing, and TechVault's
+  `validate_driver_configuration()` URI, flag, and name checks.
+- **OS/process exposure:** the change adds no subprocess, shell, argv,
+  environment dump, file, socket, daemon-inspection, or privilege surface.
+  Preserve lazy libvirt loading, structured API calls, ownership UUID checks,
+  stop-before-undefine, scoped artifact cleanup, and fail-closed teardown.
+- **Error envelopes:** public failures continue through the existing diagnostic
+  and apply-result path, then runtime backend-call validation and the control
+  plane's redacted HTTP 500 handler. Native details never enter `Diagnostic`,
+  snapshot metadata, operation details, audit reasons, or HTTP bodies.
+- **Persistence/evidence:** logs remain ephemeral operator telemetry. Do not put
+  them in `ControlPlaneStore`, `RuntimeSnapshot`, apparatus summaries, audit
+  events, or experiment records merely to make the failure durable. A future
+  evidence use requires an explicit experiment-evidence projection with the
+  existing provenance, sensitivity, redaction, and authorization contracts.
+- **Repository policy:** keep changes within ADR-036 package dependencies and
+  ADR-015's 500-line cap. No published schema, schema manifest, generated
+  fixture, or changelog change follows from this issue.
+
+## Extension Seam
+
+The extension seam is the native classifier in `_native`: native exception
+identity plus an operation-supplied tolerated-code set. Future libvirt
+operations or bindings extend that one seam and the existing fixed operation
+token vocabulary. They do not add public target configuration, observability
+schemas, vendor-specific diagnostics, or per-driver loggers.
+
+## Anti-Patterns And Non-Goals
+
+Avoid raw tracebacks; exception text at any log level; log calls scattered
+outside intentional collapse points; treating all code-bearing exceptions as
+libvirt errors; globally treating `KeyError` as absence; duplicate error-code
+constants or predicates; logging propagated failures as suppressed; changing
+portable diagnostics for richer operator detail; and exposing logs through the
+operational apparatus summary.
+
+This issue does not redesign RUN-316, scenario-native observability, evidence
+capture, the runtime control-plane API, backend manifests, libvirt lifecycle or
+ownership semantics, persistence, logger configuration, or experiment
+contracts. It does not require a new ADR because ADR-066 already owns the
+architectural decision.

--- a/implementations/python/packages/raes_backend_libvirt/_observability.py
+++ b/implementations/python/packages/raes_backend_libvirt/_observability.py
@@ -13,7 +13,21 @@ import logging
 import re
 
 LOGGER = logging.getLogger("raes_backend_libvirt")
-_SAFE_TYPE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_SAFE_TOKEN_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_MAX_TOKEN_LENGTH = 80
+_MIN_SAFE_INTEGER = -(2**31)
+_MAX_SAFE_INTEGER = 2**31 - 1
+
+
+def _safe_token(value: object, *, fallback: str) -> str:
+    candidate = value if type(value) is str else fallback
+    return _SAFE_TOKEN_RE.sub("-", candidate)[:_MAX_TOKEN_LENGTH] or fallback
+
+
+def _bounded_integer(value: object) -> int | None:
+    if type(value) is not int or not _MIN_SAFE_INTEGER <= value <= _MAX_SAFE_INTEGER:
+        return None
+    return value
 
 
 def record_suppressed_failure(
@@ -24,10 +38,22 @@ def record_suppressed_failure(
 ) -> None:
     """Record bounded failure classification without exception text or traceback."""
 
-    exception_type = _SAFE_TYPE_RE.sub("-", type(exc).__name__)[:80] or "Exception"
+    operation_token = _safe_token(operation, fallback="operation")
+    exception_type = _safe_token(type(exc).__name__, fallback="Exception")
     fields = [f"exception_type={exception_type}"]
-    if isinstance(exc, OSError) and type(exc.errno) is int:
-        fields.append(f"errno={exc.errno}")
-    if type(native_code) is int:
-        fields.append(f"native_code={native_code}")
-    LOGGER.debug("%s suppressed backend failure (%s)", operation, ", ".join(fields))
+    error_number = None
+    if isinstance(exc, OSError):
+        try:
+            error_number = _bounded_integer(exc.errno)
+        except Exception:
+            error_number = None
+    if error_number is not None:
+        fields.append(f"errno={error_number}")
+    bounded_native_code = _bounded_integer(native_code)
+    if bounded_native_code is not None:
+        fields.append(f"native_code={bounded_native_code}")
+    try:
+        LOGGER.debug("%s suppressed backend failure (%s)", operation_token, ", ".join(fields))
+    except Exception:
+        # Operator telemetry must never replace the portable backend outcome.
+        return

--- a/implementations/python/packages/raes_backend_libvirt/_techvault_native_ops.py
+++ b/implementations/python/packages/raes_backend_libvirt/_techvault_native_ops.py
@@ -15,7 +15,7 @@ from typing import Protocol, cast
 
 from raes_contracts.diagnostics import Diagnostic, Severity
 
-from .drivers.libvirt import _error_code, _existing_uuid, _raes_uuid
+from .drivers.libvirt import _existing_uuid, _is_expected_lookup_absence, _raes_uuid
 from .techvault_lifecycle import (
     NativeOwnershipConflict as _OwnershipConflict,
 )
@@ -54,7 +54,7 @@ def _ensure_name_available(connection: object, method_name: str, name: str, addr
     except KeyError:
         return
     except Exception as exc:
-        if _error_code(exc) in {42, 43}:
+        if _is_expected_lookup_absence(exc, method_name):
             return
         raise
     if _existing_uuid(native) != _raes_uuid(address):

--- a/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/__init__.py
+++ b/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/__init__.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from ._native import _ABSENCE_ERROR_CODES as _ABSENCE_ERROR_CODES
+from ._native import _DEACTIVATE_TOLERATED_ERROR_CODES as _DEACTIVATE_TOLERATED_ERROR_CODES
 from ._native import Connector as Connector
 from ._native import _error_code as _error_code
 from ._native import _existing_uuid as _existing_uuid
 from ._native import _filter_owner_uuid as _filter_owner_uuid
+from ._native import _is_absence_error as _is_absence_error
+from ._native import _is_expected_list_absence as _is_expected_list_absence
+from ._native import _is_expected_lookup_absence as _is_expected_lookup_absence
+from ._native import _list_absence_error_codes as _list_absence_error_codes
 from ._native import _raes_uuid as _raes_uuid
 from .deployment import LibvirtDeploymentDriver as LibvirtDeploymentDriver

--- a/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/_deployment_diagnostics.py
+++ b/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/_deployment_diagnostics.py
@@ -1,0 +1,39 @@
+"""Portable diagnostic construction for the generic libvirt driver."""
+
+from __future__ import annotations
+
+from raes_contracts.diagnostics import Diagnostic, Severity
+
+_DOMAIN = "runtime"
+_CODE_OPERATION_FAILED = "libvirt-backend.driver.operation-failed"
+_CODE_UNAVAILABLE = "libvirt-backend.driver.unavailable"
+_CODE_OWNERSHIP_CONFLICT = "libvirt-backend.driver.ownership-conflict"
+_CONNECTION_ADDRESS = "runtime.libvirt.connection"
+
+_FAILURE_MESSAGES = {
+    _CODE_UNAVAILABLE: "Libvirt connection is unavailable for this backend operation.",
+    _CODE_OWNERSHIP_CONFLICT: (
+        "Libvirt object for '{address}' already exists under the same name but is not "
+        "owned by this RAES address; refusing to converge an object this plan does not own."
+    ),
+}
+
+
+def _failure(address: str, code: str) -> Diagnostic:
+    template = _FAILURE_MESSAGES.get(code, "Libvirt operation for '{address}' did not succeed.")
+    return Diagnostic(
+        code=code,
+        domain=_DOMAIN,
+        address=address,
+        message=template.format(address=address),
+        severity=Severity.ERROR,
+    )
+
+
+__all__ = [
+    "_CODE_OPERATION_FAILED",
+    "_CODE_OWNERSHIP_CONFLICT",
+    "_CODE_UNAVAILABLE",
+    "_CONNECTION_ADDRESS",
+    "_failure",
+]

--- a/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/_native.py
+++ b/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/_native.py
@@ -65,16 +65,14 @@ def _error_code(exc: BaseException) -> int | None:
     int, yields None so callers treat it as an unclassified real failure.
     """
 
-    if not _is_libvirt_error(exc):
-        return None
-    try:
-        getter = getattr(exc, "get_error_code", None)
-        if not callable(getter):
-            return None
-        code = getter()
-    except Exception as classifier_error:
-        _record_suppressed_failure("_error_code", classifier_error)
-        return None
+    code: object | None = None
+    if _is_libvirt_error(exc):
+        try:
+            getter = getattr(exc, "get_error_code", None)
+            if callable(getter):
+                code = getter()
+        except Exception as classifier_error:
+            _record_suppressed_failure("_error_code", classifier_error)
     return code if isinstance(code, int) else None
 
 

--- a/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/_native.py
+++ b/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/_native.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import importlib
 import re
+import sys
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Set
 from typing import Protocol, cast
 
 from raes_backend_libvirt._observability import record_suppressed_failure as _record_suppressed_failure
@@ -31,11 +32,22 @@ _RAES_UUID_NAMESPACE = uuid.UUID("af20aedd-47bd-5870-b3f8-2f1baebde508")
 # "do not treat every libvirt lookup exception as not found").
 _VIR_ERR_NO_DOMAIN = 42
 _VIR_ERR_NO_NETWORK = 43
+_VIR_ERR_NO_NWFILTER = 62
 # Raised by destroy() on an object that is not running; stopping an already-stopped
 # object is a benign no-op on the teardown path, distinct from a permission/internal
 # stop failure that must fail closed.
 _VIR_ERR_OPERATION_INVALID = 55
-_ABSENCE_ERROR_CODES: frozenset[int] = frozenset({_VIR_ERR_NO_DOMAIN, _VIR_ERR_NO_NETWORK})
+_ABSENCE_ERROR_CODES: frozenset[int] = frozenset({_VIR_ERR_NO_DOMAIN, _VIR_ERR_NO_NETWORK, _VIR_ERR_NO_NWFILTER})
+_DEACTIVATE_TOLERATED_ERROR_CODES = _ABSENCE_ERROR_CODES | {_VIR_ERR_OPERATION_INVALID}
+_LOOKUP_ABSENCE_ERROR_CODES = {
+    "lookupByName": frozenset({_VIR_ERR_NO_DOMAIN}),
+    "networkLookupByName": frozenset({_VIR_ERR_NO_NETWORK}),
+    "nwfilterLookupByName": frozenset({_VIR_ERR_NO_NWFILTER}),
+}
+_LIST_ABSENCE_ERROR_CODES = {
+    "listAllDomains": frozenset({_VIR_ERR_NO_DOMAIN}),
+    "listAllNetworks": frozenset({_VIR_ERR_NO_NETWORK}),
+}
 
 
 class _OwnershipConflict(Exception):
@@ -53,15 +65,44 @@ def _error_code(exc: BaseException) -> int | None:
     int, yields None so callers treat it as an unclassified real failure.
     """
 
-    getter = getattr(exc, "get_error_code", None)
-    if not callable(getter):
+    if not _is_libvirt_error(exc):
         return None
     try:
+        getter = getattr(exc, "get_error_code", None)
+        if not callable(getter):
+            return None
         code = getter()
-    except Exception as exc:
-        _record_suppressed_failure("_error_code", exc)
+    except Exception as classifier_error:
+        _record_suppressed_failure("_error_code", classifier_error)
         return None
     return code if isinstance(code, int) else None
+
+
+def _is_libvirt_error(exc: BaseException) -> bool:
+    """Recognize the loaded binding's native exception family by identity."""
+
+    try:
+        module = sys.modules.get("libvirt")
+        error_type = getattr(module, "libvirtError", None)
+        return isinstance(error_type, type) and issubclass(error_type, BaseException) and isinstance(exc, error_type)
+    except Exception:
+        return False
+
+
+def _is_expected_lookup_absence(exc: BaseException, method_name: str) -> bool:
+    return _error_code(exc) in _lookup_absence_error_codes(method_name)
+
+
+def _is_expected_list_absence(exc: BaseException, method_name: str) -> bool:
+    return _error_code(exc) in _list_absence_error_codes(method_name)
+
+
+def _lookup_absence_error_codes(method_name: str) -> Set[int]:
+    return _LOOKUP_ABSENCE_ERROR_CODES.get(method_name, frozenset())
+
+
+def _list_absence_error_codes(method_name: str) -> Set[int]:
+    return _LIST_ABSENCE_ERROR_CODES.get(method_name, frozenset())
 
 
 def _is_absence_error(exc: BaseException) -> bool:
@@ -141,7 +182,7 @@ def _lookup(connection: object, method_name: str, name: str) -> object | None:
         return method(name)
     except Exception as exc:
         code = _error_code(exc)
-        if code not in _ABSENCE_ERROR_CODES:
+        if code not in _lookup_absence_error_codes(method_name):
             _record_suppressed_failure("_lookup", exc, native_code=code)
         return None
 
@@ -161,7 +202,7 @@ def _stop_native(native: object) -> None:
         cast(_NativeResource, native).destroy()
     except Exception as exc:
         code = _error_code(exc)
-        if code == _VIR_ERR_OPERATION_INVALID or code in _ABSENCE_ERROR_CODES:
+        if code in _DEACTIVATE_TOLERATED_ERROR_CODES:
             return
         raise
 
@@ -182,7 +223,7 @@ def _find_native(connection: object, method_name: str, name: str) -> object | No
     try:
         return method(name)
     except Exception as exc:
-        if _is_absence_error(exc):
+        if _is_expected_lookup_absence(exc, method_name):
             return None
         raise _NativeLookupError(method_name) from exc
 

--- a/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/deployment.py
+++ b/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/deployment.py
@@ -448,22 +448,21 @@ class LibvirtDeploymentDriver:
             return
         if native is None:
             self._filters.pop(address, None)
-            return
-        if _existing_uuid(native) != _filter_owner_uuid(address):
+        elif _existing_uuid(native) != _filter_owner_uuid(address):
             # A filter at this name we do not own must never be undefined.
             self._filters.pop(address, None)
-            return
-        # Best-effort cleanup of our own filter: a filter that cannot be undefined
-        # (in use, missing) must not fail the destroy.
-        try:
-            cast(_NativeResource, native).undefine()
-        except Exception as exc:
-            if _is_absence_error(exc):
-                self._filters.pop(address, None)
-            else:
-                _record_suppressed_failure("_undefine_nwfilter", exc)
         else:
-            self._filters.pop(address, None)
+            # Best-effort cleanup of our own filter: a filter that cannot be
+            # undefined (in use, missing) must not fail the destroy.
+            try:
+                cast(_NativeResource, native).undefine()
+            except Exception as exc:
+                if _is_absence_error(exc):
+                    self._filters.pop(address, None)
+                else:
+                    _record_suppressed_failure("_undefine_nwfilter", exc)
+            else:
+                self._filters.pop(address, None)
 
     def _destroy_one(self, connection: object, lookup_method: str, address: str) -> bool:
         removed = True

--- a/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/deployment.py
+++ b/implementations/python/packages/raes_backend_libvirt/drivers/libvirt/deployment.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import cast
 
 from raes_backend_protocols.naming import provider_resource_name
-from raes_contracts.diagnostics import Diagnostic, Severity
+from raes_contracts.diagnostics import Diagnostic
 from raes_contracts.realization_envelope import ObservationStrength, RealizationConcern
 from raes_contracts.realization_observation import RealizationObservation
 
@@ -26,6 +26,13 @@ from ...envelopes import load_libvirt_realization_envelope
 from .._libvirt_xml import _domain_xml, _network_xml, _nwfilter_xml
 from ..seed import _SEED_DIR_MODE, GenisoimageSeedBuilder, SeedBuilder, write_seed_files
 from ._deployment_batch import realize_domain_specs, realize_network_specs
+from ._deployment_diagnostics import (
+    _CODE_OPERATION_FAILED,
+    _CODE_OWNERSHIP_CONFLICT,
+    _CODE_UNAVAILABLE,
+    _CONNECTION_ADDRESS,
+    _failure,
+)
 from ._native import (
     Connector,
     _call_libvirt,
@@ -34,7 +41,6 @@ from ._native import (
     _filter_owner_uuid,
     _find_native,
     _is_absence_error,
-    _lookup,
     _NativeLookupError,
     _NativeResource,
     _OwnershipConflict,
@@ -43,11 +49,6 @@ from ._native import (
     _stop_native,
 )
 
-_DOMAIN = "runtime"
-_CODE_OPERATION_FAILED = "libvirt-backend.driver.operation-failed"
-_CODE_UNAVAILABLE = "libvirt-backend.driver.unavailable"
-_CODE_OWNERSHIP_CONFLICT = "libvirt-backend.driver.ownership-conflict"
-_CONNECTION_ADDRESS = "runtime.libvirt.connection"
 _DEFAULT_CONNECTION_URI = "qemu:///system"
 _WORKSPACE_PREFIX = "raes-libvirt-"
 
@@ -391,7 +392,12 @@ class LibvirtDeploymentDriver:
         # refuse to redefine a filter at this name unless it is owner-stamped for
         # this RAES address. A foreign filter (or one for another address that
         # normalizes to the same name) is never overwritten; apply fails closed.
-        existing = _lookup(connection, "nwfilterLookupByName", filter_name)
+        # Unlike domain/network definition, nwfilterDefineXML is an upsert and
+        # cannot surface a lookup failure as a later duplicate-name conflict.
+        # Distinguish proven absence from every other lookup failure here so a
+        # mismatched native error can never authorize replacing a host-global
+        # filter whose ownership was not verified.
+        existing = _find_native(connection, "nwfilterLookupByName", filter_name)
         if existing is not None and _existing_uuid(existing) != owner:
             raise _OwnershipConflict(filter_name)
         define = getattr(connection, "nwfilterDefineXML", None)
@@ -422,7 +428,7 @@ class LibvirtDeploymentDriver:
         failure, never a pre-existing resource an UPDATE would otherwise destroy.
         """
 
-        native = _lookup(connection, lookup_method, name)
+        native = _find_native(connection, lookup_method, name)
         if native is None:
             return False
         if _existing_uuid(native) != _raes_uuid(address):
@@ -432,22 +438,32 @@ class LibvirtDeploymentDriver:
         return True
 
     def _undefine_nwfilter(self, connection: object, address: str) -> None:
-        filter_name = self._filters.pop(address, None)
+        filter_name = self._filters.get(address)
         if filter_name is None:
             return
-        native = _lookup(connection, "nwfilterLookupByName", filter_name)
+        try:
+            native = _find_native(connection, "nwfilterLookupByName", filter_name)
+        except _NativeLookupError as exc:
+            _record_suppressed_failure("_undefine_nwfilter", exc.__cause__ or exc)
+            return
         if native is None:
+            self._filters.pop(address, None)
             return
         if _existing_uuid(native) != _filter_owner_uuid(address):
             # A filter at this name we do not own must never be undefined.
+            self._filters.pop(address, None)
             return
         # Best-effort cleanup of our own filter: a filter that cannot be undefined
         # (in use, missing) must not fail the destroy.
         try:
             cast(_NativeResource, native).undefine()
         except Exception as exc:
-            if not _is_absence_error(exc):
+            if _is_absence_error(exc):
+                self._filters.pop(address, None)
+            else:
                 _record_suppressed_failure("_undefine_nwfilter", exc)
+        else:
+            self._filters.pop(address, None)
 
     def _destroy_one(self, connection: object, lookup_method: str, address: str) -> bool:
         removed = True
@@ -480,19 +496,3 @@ class LibvirtDeploymentDriver:
     def _rollback(self, networks: list[str], domains: list[str]) -> None:
         if networks or domains:
             self.destroy(networks=tuple(networks), domains=tuple(domains))
-
-
-_FAILURE_MESSAGES = {
-    _CODE_UNAVAILABLE: "Libvirt connection is unavailable for this backend operation.",
-    _CODE_OWNERSHIP_CONFLICT: (
-        "Libvirt object for '{address}' already exists under the same name but is not "
-        "owned by this RAES address; refusing to converge an object this plan does not own."
-    ),
-}
-
-
-def _failure(address: str, code: str) -> Diagnostic:
-    template = _FAILURE_MESSAGES.get(code, "Libvirt operation for '{address}' did not succeed.")
-    return Diagnostic(
-        code=code, domain=_DOMAIN, address=address, message=template.format(address=address), severity=Severity.ERROR
-    )

--- a/implementations/python/packages/raes_backend_libvirt/techvault_lifecycle.py
+++ b/implementations/python/packages/raes_backend_libvirt/techvault_lifecycle.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Set
 from dataclasses import dataclass
 
 from raes_backend_libvirt._observability import record_suppressed_failure as _record_suppressed_failure
 
-from .drivers.libvirt import _error_code, _existing_uuid, _raes_uuid
+from .drivers.libvirt import (
+    _ABSENCE_ERROR_CODES,
+    _DEACTIVATE_TOLERATED_ERROR_CODES,
+    _error_code,
+    _existing_uuid,
+    _list_absence_error_codes,
+    _raes_uuid,
+)
 from .techvault_matrix import runtime_name
 
 
@@ -74,7 +81,7 @@ def _resolve_by_name(
         resolved = _resolve_verified_absence(connection, list_method, address)
     except Exception as exc:
         code = _error_code(exc)
-        if code in {42, 43}:
+        if code in _list_absence_error_codes(list_method):
             resolved = _resolve_verified_absence(connection, list_method, address)
         else:
             _record_suppressed_failure("_resolve_by_name", exc, native_code=code)
@@ -107,14 +114,14 @@ def verify_native_removed(
 
 
 def deactivate_and_undefine(native: object) -> bool:
-    return _invoke_native_action(native, "destroy", {42, 43, 55}) and _invoke_native_action(
+    return _invoke_native_action(native, "destroy", _DEACTIVATE_TOLERATED_ERROR_CODES) and _invoke_native_action(
         native,
         "undefine",
-        {42, 43},
+        _ABSENCE_ERROR_CODES,
     )
 
 
-def _invoke_native_action(native: object, method_name: str, tolerated_codes: set[int]) -> bool:
+def _invoke_native_action(native: object, method_name: str, tolerated_codes: Set[int]) -> bool:
     method = getattr(native, method_name, None)
     if not callable(method):
         return False

--- a/implementations/python/tests/test_libvirt_backend_driver.py
+++ b/implementations/python/tests/test_libvirt_backend_driver.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
+from types import ModuleType
 
+import pytest
 from raes_backend_libvirt.cloudinit import CloudInitSpec, CloudInitUser
 from raes_backend_libvirt.driver import DomainSpec, NetworkAcl, NetworkSpec
 from raes_backend_libvirt.drivers.libvirt import LibvirtDeploymentDriver, _raes_uuid
@@ -19,7 +22,7 @@ _VIR_ERR_INTERNAL_ERROR = 1
 _VIR_ERR_NO_DOMAIN = 42
 _VIR_ERR_NO_NETWORK = 43
 _VIR_ERR_OPERATION_INVALID = 55
-_VIR_ERR_NO_NWFILTER = 620
+_VIR_ERR_NO_NWFILTER = 62
 
 
 def _runtime_name(address: str) -> str:
@@ -39,6 +42,13 @@ class _FakeLibvirtError(Exception):
 
     def get_error_code(self) -> int:
         return self._code
+
+
+@pytest.fixture(autouse=True)
+def _install_fake_libvirt_error_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    libvirt = ModuleType("libvirt")
+    libvirt.libvirtError = _FakeLibvirtError
+    monkeypatch.setitem(sys.modules, "libvirt", libvirt)
 
 
 def _xml_attr(xml: str, attr: str) -> str:
@@ -564,6 +574,60 @@ def test_libvirt_nwfilter_define_refuses_to_overwrite_a_foreign_filter():
     assert [d.code for d in result.diagnostics] == ["libvirt-backend.driver.ownership-conflict"]
     assert connection.nwfilter_xml == []  # the foreign filter was never redefined
     assert connection.nwfilters[filter_name] is foreign
+
+
+def test_libvirt_nwfilter_define_fails_closed_on_a_mismatched_absence_code():
+    class _MismatchedAbsenceConnection(_FakeConnection):
+        def nwfilterLookupByName(self, name: str):  # noqa: N802 - mirrors libvirt API
+            del name
+            raise _FakeLibvirtError(_VIR_ERR_NO_DOMAIN)
+
+    connection = _MismatchedAbsenceConnection()
+    driver = LibvirtDeploymentDriver(connection=connection, name_prefix="raes-test")
+    acl = NetworkAcl(name="allow-all", action="accept", direction="inout", protocol="all")
+
+    result = driver.realize(
+        networks=(),
+        domains=(DomainSpec(address="provision.node.web", name="web", image_ref=None, network_acls=(acl,)),),
+    )
+
+    assert [diagnostic.code for diagnostic in result.diagnostics] == ["libvirt-backend.driver.operation-failed"]
+    assert connection.nwfilter_xml == []
+    assert connection.domain_xml == []
+
+
+def test_libvirt_domain_convergence_fails_closed_on_a_mismatched_absence_code():
+    class _MismatchedAbsenceConnection(_FakeConnection):
+        def lookupByName(self, name: str):  # noqa: N802 - mirrors libvirt API
+            del name
+            raise _FakeLibvirtError(_VIR_ERR_NO_NETWORK)
+
+    connection = _MismatchedAbsenceConnection()
+    driver = LibvirtDeploymentDriver(connection=connection, name_prefix="raes-test")
+
+    result = driver.realize(
+        networks=(),
+        domains=(DomainSpec(address="provision.node.web", name="web", image_ref=None),),
+    )
+
+    assert [diagnostic.code for diagnostic in result.diagnostics] == ["libvirt-backend.driver.operation-failed"]
+    assert connection.domain_xml == []
+
+
+def test_libvirt_nwfilter_cleanup_preserves_retry_state_on_a_mismatched_absence_code():
+    class _MismatchedAbsenceConnection(_FakeConnection):
+        def nwfilterLookupByName(self, name: str):  # noqa: N802 - mirrors libvirt API
+            del name
+            raise _FakeLibvirtError(_VIR_ERR_NO_DOMAIN)
+
+    address = "provision.node.web"
+    connection = _MismatchedAbsenceConnection()
+    driver = LibvirtDeploymentDriver(connection=connection, name_prefix="raes-test")
+    driver._filters[address] = "raes-test-web-acl"
+
+    driver._undefine_nwfilter(connection, address)
+
+    assert driver._filters[address] == "raes-test-web-acl"
 
 
 def test_libvirt_destroy_refuses_to_remove_a_foreign_object():

--- a/implementations/python/tests/test_libvirt_failure_observability.py
+++ b/implementations/python/tests/test_libvirt_failure_observability.py
@@ -9,11 +9,13 @@ empty result), and bounded failure classification is recorded on the
 from __future__ import annotations
 
 import logging
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
-from raes_backend_libvirt import _initramfs
+from raes_backend_libvirt import _initramfs, _observability
 from raes_backend_libvirt._observability import record_suppressed_failure
+from raes_backend_libvirt._techvault_native_ops import _ensure_name_available
 from raes_backend_libvirt.driver import DomainSpec, NetworkSpec
 from raes_backend_libvirt.drivers.libvirt import _native
 from raes_backend_libvirt.drivers.libvirt import deployment as _deployment
@@ -49,6 +51,17 @@ class _NativeError(RuntimeError):
         return self._level
 
 
+class _ForeignCodeError(RuntimeError):
+    """A non-libvirt exception that happens to expose a libvirt-like method."""
+
+    def __init__(self, code: int) -> None:
+        super().__init__(_SENSITIVE_DETAIL)
+        self._code = code
+
+    def get_error_code(self) -> int:
+        return self._code
+
+
 def _raiser(*_args: object, **_kwargs: object) -> object:
     raise RuntimeError("forced native failure")
 
@@ -68,7 +81,10 @@ def _assert_recorded(caplog: pytest.LogCaptureFixture, operation: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _capture_debug(caplog: pytest.LogCaptureFixture):
+def _capture_debug(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch):
+    libvirt = ModuleType("libvirt")
+    libvirt.libvirtError = _NativeError
+    monkeypatch.setitem(sys.modules, "libvirt", libvirt)
     caplog.set_level(logging.DEBUG, logger=_OBSERVABILITY_LOGGER)
     return caplog
 
@@ -82,8 +98,41 @@ def test_failure_record_is_bounded_and_uses_only_safe_classification(caplog: pyt
     assert len(message) < 256
 
 
+def test_failure_record_bounds_every_caller_supplied_field(caplog: pytest.LogCaptureFixture) -> None:
+    huge_integer = 10**1000
+
+    record_suppressed_failure(
+        "unsafe/" + ("operation" * 100), OSError(huge_integer, _SENSITIVE_DETAIL), native_code=huge_integer
+    )
+
+    message = caplog.records[-1].getMessage()
+    assert len(message) < 256
+    assert _SENSITIVE_DETAIL not in message
+    assert str(huge_integer) not in message
+
+
+def test_failure_record_does_not_interfere_when_errno_access_raises(caplog: pytest.LogCaptureFixture) -> None:
+    class _HostileOSError(OSError):
+        @property
+        def errno(self) -> int:
+            raise RuntimeError(_SENSITIVE_DETAIL)
+
+    record_suppressed_failure("safe_operation", _HostileOSError())
+
+    _assert_recorded(caplog, "safe_operation")
+
+
+def test_failure_record_does_not_interfere_when_logger_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_observability.LOGGER, "debug", _raiser)
+
+    record_suppressed_failure("safe_operation", RuntimeError(_SENSITIVE_DETAIL))
+
+
 def test_error_code_records_a_raising_classifier(caplog: pytest.LogCaptureFixture) -> None:
-    class _WeirdError(Exception):
+    class _WeirdError(_NativeError):
+        def __init__(self) -> None:
+            super().__init__(1)
+
         def get_error_code(self) -> int:
             raise RuntimeError("classifier exploded")
 
@@ -114,13 +163,115 @@ def test_lookup_keeps_expected_native_absence_silent(caplog: pytest.LogCaptureFi
     assert not [record for record in caplog.records if _SUPPRESSED in record.getMessage()]
 
 
+def test_lookup_keeps_expected_nwfilter_absence_silent(caplog: pytest.LogCaptureFixture) -> None:
+    def absent(_name: str) -> object:
+        raise _NativeError(62)
+
+    assert _native._lookup(SimpleNamespace(nwfilterLookupByName=absent), "nwfilterLookupByName", "missing") is None
+    assert not [record for record in caplog.records if _SUPPRESSED in record.getMessage()]
+
+
 def test_lookup_records_non_absence_failure(caplog: pytest.LogCaptureFixture) -> None:
     assert _native._lookup(SimpleNamespace(lookupByName=_raiser), "lookupByName", "missing") is None
     _assert_recorded(caplog, "_lookup")
 
 
+def test_lookup_does_not_misclassify_a_foreign_code_bearing_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def foreign_absence(_name: str) -> object:
+        raise _ForeignCodeError(42)
+
+    assert _native._lookup(SimpleNamespace(lookupByName=foreign_absence), "lookupByName", "missing") is None
+    _assert_recorded(caplog, "_lookup")
+
+
+def test_lookup_does_not_accept_another_native_resource_type_absence(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def network_absence_during_domain_lookup(_name: str) -> object:
+        raise _NativeError(43)
+
+    assert (
+        _native._lookup(
+            SimpleNamespace(lookupByName=network_absence_during_domain_lookup),
+            "lookupByName",
+            "missing",
+        )
+        is None
+    )
+    _assert_recorded(caplog, "_lookup")
+
+
+def test_find_native_does_not_misclassify_a_foreign_code_bearing_exception() -> None:
+    def foreign_absence(_name: str) -> object:
+        raise _ForeignCodeError(42)
+
+    with pytest.raises(_native._NativeLookupError):
+        _native._find_native(SimpleNamespace(lookupByName=foreign_absence), "lookupByName", "missing")
+
+
+def test_find_native_rejects_another_native_resource_type_absence() -> None:
+    def network_absence_during_domain_lookup(_name: str) -> object:
+        raise _NativeError(43)
+
+    with pytest.raises(_native._NativeLookupError):
+        _native._find_native(
+            SimpleNamespace(lookupByName=network_absence_during_domain_lookup),
+            "lookupByName",
+            "missing",
+        )
+
+
+def test_stop_native_does_not_tolerate_a_foreign_operation_invalid_code() -> None:
+    def foreign_inactive() -> None:
+        raise _ForeignCodeError(55)
+
+    with pytest.raises(_ForeignCodeError):
+        _native._stop_native(SimpleNamespace(destroy=foreign_inactive))
+
+
 def test_resolve_by_name_records_non_absence_failure(caplog: pytest.LogCaptureFixture) -> None:
     assert _resolve_by_name(object(), _raiser, "listAllDomains", "provision.node.web", "web") is None
+    _assert_recorded(caplog, "_resolve_by_name")
+
+
+def test_resolve_by_name_does_not_verify_absence_for_a_foreign_code_bearing_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    list_calls: list[str] = []
+
+    def foreign_absence(_name: str) -> object:
+        raise _ForeignCodeError(42)
+
+    connection = SimpleNamespace(listAllDomains=lambda: list_calls.append("listed") or [])
+
+    assert _resolve_by_name(connection, foreign_absence, "listAllDomains", "provision.node.web", "web") is None
+    assert list_calls == []
+    _assert_recorded(caplog, "_resolve_by_name")
+
+
+def test_resolve_by_name_does_not_verify_another_native_resource_type_absence(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    list_calls: list[str] = []
+
+    def domain_absence_during_network_lookup(_name: str) -> object:
+        raise _NativeError(42)
+
+    connection = SimpleNamespace(listAllNetworks=lambda: list_calls.append("listed") or [])
+
+    assert (
+        _resolve_by_name(
+            connection,
+            domain_absence_during_network_lookup,
+            "listAllNetworks",
+            "provision.network.lan",
+            "lan",
+        )
+        is None
+    )
+    assert list_calls == []
     _assert_recorded(caplog, "_resolve_by_name")
 
 
@@ -135,6 +286,52 @@ def test_native_action_keeps_tolerated_failure_silent(caplog: pytest.LogCaptureF
 
     assert _invoke_native_action(SimpleNamespace(destroy=absent), "destroy", {42, 43})
     assert not [record for record in caplog.records if _SUPPRESSED in record.getMessage()]
+
+
+def test_native_action_does_not_tolerate_a_foreign_code_bearing_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def foreign_absence() -> None:
+        raise _ForeignCodeError(42)
+
+    assert not _invoke_native_action(SimpleNamespace(destroy=foreign_absence), "destroy", {42, 43})
+    _assert_recorded(caplog, "_invoke_native_action")
+
+
+def test_native_action_does_not_tolerate_an_unlisted_native_absence_code(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def network_absence() -> None:
+        raise _NativeError(43)
+
+    assert not _invoke_native_action(SimpleNamespace(destroy=network_absence), "destroy", {42})
+    _assert_recorded(caplog, "_invoke_native_action")
+
+
+def test_name_availability_does_not_treat_a_foreign_code_bearing_exception_as_absence() -> None:
+    def foreign_absence(_name: str) -> object:
+        raise _ForeignCodeError(42)
+
+    with pytest.raises(_ForeignCodeError):
+        _ensure_name_available(
+            SimpleNamespace(lookupByName=foreign_absence),
+            "lookupByName",
+            "raestest-web",
+            "provision.node.web",
+        )
+
+
+def test_name_availability_rejects_another_native_resource_type_absence() -> None:
+    def domain_absence_during_network_lookup(_name: str) -> object:
+        raise _NativeError(42)
+
+    with pytest.raises(_NativeError):
+        _ensure_name_available(
+            SimpleNamespace(networkLookupByName=domain_absence_during_network_lookup),
+            "networkLookupByName",
+            "raestest-lan",
+            "provision.network.lan",
+        )
 
 
 def _deployment_driver(**kwargs: object) -> LibvirtDeploymentDriver:
@@ -193,7 +390,7 @@ def test_deployment_nwfilter_cleanup_records_a_non_absence_failure(
     native = SimpleNamespace(undefine=_raiser)
     driver = _deployment_driver(connection=object())
     driver._filters["provision.node.web"] = "raestest-web-acl"
-    monkeypatch.setattr(_deployment, "_lookup", lambda *_args: native)
+    monkeypatch.setattr(_deployment, "_find_native", lambda *_args: native)
     monkeypatch.setattr(_deployment, "_existing_uuid", lambda _native: "owned")
     monkeypatch.setattr(_deployment, "_filter_owner_uuid", lambda _address: "owned")
 

--- a/implementations/python/tests/test_libvirt_failure_observability.py
+++ b/implementations/python/tests/test_libvirt_failure_observability.py
@@ -207,17 +207,21 @@ def test_find_native_does_not_misclassify_a_foreign_code_bearing_exception() -> 
     def foreign_absence(_name: str) -> object:
         raise _ForeignCodeError(42)
 
+    connection = SimpleNamespace(lookupByName=foreign_absence)
+
     with pytest.raises(_native._NativeLookupError):
-        _native._find_native(SimpleNamespace(lookupByName=foreign_absence), "lookupByName", "missing")
+        _native._find_native(connection, "lookupByName", "missing")
 
 
 def test_find_native_rejects_another_native_resource_type_absence() -> None:
     def network_absence_during_domain_lookup(_name: str) -> object:
         raise _NativeError(43)
 
+    connection = SimpleNamespace(lookupByName=network_absence_during_domain_lookup)
+
     with pytest.raises(_native._NativeLookupError):
         _native._find_native(
-            SimpleNamespace(lookupByName=network_absence_during_domain_lookup),
+            connection,
             "lookupByName",
             "missing",
         )
@@ -227,8 +231,10 @@ def test_stop_native_does_not_tolerate_a_foreign_operation_invalid_code() -> Non
     def foreign_inactive() -> None:
         raise _ForeignCodeError(55)
 
+    native = SimpleNamespace(destroy=foreign_inactive)
+
     with pytest.raises(_ForeignCodeError):
-        _native._stop_native(SimpleNamespace(destroy=foreign_inactive))
+        _native._stop_native(native)
 
 
 def test_resolve_by_name_records_non_absence_failure(caplog: pytest.LogCaptureFixture) -> None:
@@ -312,9 +318,11 @@ def test_name_availability_does_not_treat_a_foreign_code_bearing_exception_as_ab
     def foreign_absence(_name: str) -> object:
         raise _ForeignCodeError(42)
 
+    connection = SimpleNamespace(lookupByName=foreign_absence)
+
     with pytest.raises(_ForeignCodeError):
         _ensure_name_available(
-            SimpleNamespace(lookupByName=foreign_absence),
+            connection,
             "lookupByName",
             "raestest-web",
             "provision.node.web",
@@ -325,9 +333,11 @@ def test_name_availability_rejects_another_native_resource_type_absence() -> Non
     def domain_absence_during_network_lookup(_name: str) -> object:
         raise _NativeError(42)
 
+    connection = SimpleNamespace(networkLookupByName=domain_absence_during_network_lookup)
+
     with pytest.raises(_NativeError):
         _ensure_name_available(
-            SimpleNamespace(networkLookupByName=domain_absence_during_network_lookup),
+            connection,
             "networkLookupByName",
             "raestest-lan",
             "provision.network.lan",

--- a/implementations/python/tests/test_participant_concurrent_batch_reservations.py
+++ b/implementations/python/tests/test_participant_concurrent_batch_reservations.py
@@ -1403,6 +1403,10 @@ def test_service_settlement_failure_removes_state_absent_before_batch(
     assert _POLICY_ADDRESS not in run.result().snapshot.participant_execution_services
 
 
+# The completion lane runs this 800-participant stress case under coverage and
+# eight-worker CPU contention. Its assertions, rather than wall time, are the
+# deterministic complexity oracle for scans, snapshot copies, and validation.
+@pytest.mark.timeout(300)
 def test_many_participants_use_one_iterative_due_scan_and_real_settlement(monkeypatch: pytest.MonkeyPatch):
     participant_count = 800
     participants = tuple(f"participant.behavior.scale-{index:04d}" for index in range(participant_count))


### PR DESCRIPTION
## Plain-Language Summary

- Context: Libvirt lifecycle adapters intentionally collapse a small set of expected backend conditions into portable outcomes.
- Problem: Ambiguous native-error matching and unsafe telemetry extraction could turn real failures into successful no-ops or let logging alter control flow.
- Fix: Classify only genuine native errors with operation-specific codes and emit bounded, non-interfering failure metadata.

## Summary

Harden libvirt failure telemetry and native error classification so hostile exception and logging behavior cannot alter backend control flow, while preserving retry state for non-absence failures.

## Requirement UIDs

- `RUN-316`

## Related Issues

Closes #1173

## ADR Impact

- ADR-015
- ADR-036
- ADR-066

## Changes

- Bound and sanitize suppressed-failure metadata while making logger and exception inspection non-interfering.
- Centralize operation-specific native libvirt error classification and apply it across deployment and TechVault lifecycle paths.
- Add adversarial regression coverage for native identity, mismatched resource codes, fail-closed deployment, retry state, and stress-test timing.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Focused libvirt suite: 364 passed, 2 deselected. Full Python unit suite: 7,235 passed, 3 skipped, 4 xfailed. Ground Control completion, policy, and pre-commit gates passed.

## Verification

- `pytest implementations/python/tests/test_libvirt_failure_observability.py implementations/python/tests/test_libvirt_backend_driver.py`: 364 passed, 2 deselected.
- Full Python unit suite: 7,235 passed, 3 skipped, 4 xfailed.
- Ground Control completion, repository policy, pre-commit, and canonical CI verification passed.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: RUN-316 ← implementations/python/packages/raes_backend_libvirt/_observability.py, RUN-316 ← implementations/python/packages/raes_backend_libvirt/drivers/libvirt/_native.py, RUN-316 ← implementations/python/packages/raes_backend_libvirt/drivers/libvirt/deployment.py, RUN-316 ← implementations/python/packages/raes_backend_libvirt/techvault_lifecycle.py
- TESTS: RUN-316 ← implementations/python/tests/test_libvirt_failure_observability.py, RUN-316 ← implementations/python/tests/test_libvirt_backend_driver.py, RUN-316 ← implementations/python/tests/test_participant_concurrent_batch_reservations.py

## Issue Tracking

Closes #1173

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
