### PR TITLE
fix: allow draft release inspection

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,7 +64,7 @@ jobs:
       || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write       # draft Releases are visible only to push-capable tokens
     outputs:
       release_sha: ${{ steps.resolve.outputs.release_sha }}
       base_sha: ${{ steps.resolve.outputs.base_sha }}
@@ -75,6 +75,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve and bind the immutable release commit
         id: resolve
@@ -434,7 +435,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      contents: read
+      contents: write   # revalidate the still-draft Release after environment approval
       id-token: write   # OIDC trusted publishing to PyPI (no stored token)
     steps:
       - name: Download the tested release distributions
@@ -558,6 +559,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.resolve-release.outputs.release_sha }}
+          persist-credentials: false
 
       - name: Download the tested release distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/docs/decisions/issue-1125-gov-928-exact-sha-release-verification-preflight.md
+++ b/docs/decisions/issue-1125-gov-928-exact-sha-release-verification-preflight.md
@@ -10,6 +10,11 @@ publication. It is a focused remediation of the current Release Please path; it
 does not change package dependencies, Python support, version calculation,
 release-note ownership, contract semantics, or the release artifact format.
 
+Issue #1190 amends the permission boundary below: GitHub exposes a draft
+Release only to a push-capable identity. A `GITHUB_TOKEN` with
+`contents: read` therefore cannot perform the resolution or pre-PyPI draft
+revalidation required by this design, even though both operations are reads.
+
 ## Binding Contract And Lineage
 
 - GOV-928 requires short-lived, identity-bound package publication and forbids
@@ -82,8 +87,8 @@ into a passing required check.
 ### Resolve once, then carry the exact release SHA
 
 Release Please creates a draft GitHub Release and force-creates its tag so no
-public Release or generated source archives precede admission. Add a
-non-privileged release-resolution job before verification:
+public Release or generated source archives precede admission. Add a dedicated
+release-resolution job before verification:
 
 - For an automatic release, consume Release Please's documented `sha` output
   and require the emitted tag to resolve to that same commit.
@@ -139,14 +144,28 @@ that every specific distribution about to be uploaded satisfies the contract.
 
 ## Trust, Provenance, And Permission Boundaries
 
-- The resolution, verification, real-container, and build/smoke jobs receive only
-  `contents: read`. They do not receive `id-token: write`, the `pypi`
-  environment, or release-write authority. The tested distributions cross into
-  the publish job through a same-run immutable Actions artifact.
-- The `publish-pypi` job remains the sole holder of `id-token: write` and keeps
-  the `pypi` environment. PyPI Trusted Publishing exchanges the workflow
-  identity for short-lived credentials and requires this permission; no API
-  token or inherited secret is introduced:
+- Keep the workflow default at `contents: read`. The resolution job requires
+  job-scoped `contents: write` only because GitHub's draft-visibility rule uses
+  push capability as its authorization gate. It must receive no
+  `id-token: write`, `pypi` environment, pull-request authority, PAT, or other
+  secret. Any checkout in a `contents: write` job, including the existing
+  GitHub-publication checkout, must not persist the elevated credential for
+  subsequent Git commands; `gh` receives `github.token` through a step-local
+  `GH_TOKEN` environment binding.
+- Canonical verification, real-container verification, and build/smoke remain
+  `contents: read`. The tested distributions cross into publication through a
+  same-run SHA-named Actions artifact.
+- The `publish-pypi` job requires job-scoped `contents: write` as well as
+  `id-token: write` so it can re-read the still-draft Release after any protected
+  environment wait. GitHub Actions cannot reduce token permissions per step, so
+  this is an unavoidable aggregation at that boundary, not permission for a
+  second GitHub mutation path. Keep the job checkout-free, bind `GH_TOKEN` only
+  on the revalidation step, and keep the pinned PyPI action immediately after
+  successful identity validation.
+- `publish-pypi` remains the sole holder of `id-token: write` and keeps the
+  `pypi` environment. PyPI Trusted Publishing exchanges the workflow identity
+  for short-lived credentials and requires this permission; no API token or
+  inherited secret is introduced:
   <https://docs.pypi.org/trusted-publishers/using-a-publisher/>.
 - Publishing-critical third-party actions remain pinned to full commit SHAs,
   which GitHub identifies as the immutable action reference:
@@ -199,6 +218,12 @@ assert these structural invariants:
 - wheel and sdist archive checks and installed-artifact conformance smokes all
   precede the SHA-pinned PyPI action;
 - only `publish-pypi` has the `pypi` environment and `id-token: write`;
+- the workflow default remains `contents: read`, every job whose shell requests
+  or parses Release draft state explicitly has `contents: write`, and unrelated
+  verification/build jobs remain read-only. Discover those jobs from parsed
+  step bodies rather than enumerating only the two currently broken job names,
+  so a future lookup cannot evade the permission assertion, and require
+  non-persisted credentials on checkouts in write-scoped jobs;
 - GitHub attachment is a separate retryable job that revalidates the Release
   and tag, attaches artifacts, revalidates the object after upload, and only
   then removes draft state by numeric Release id. An already-public retry must

--- a/docs/explain/releasing.md
+++ b/docs/explain/releasing.md
@@ -48,6 +48,15 @@ verification graph to pass for the exact commit named by the release (GOV-928).
    byte-comparing both attached distributions and rechecking the id, tag, and
    commit SHA.
 
+GitHub exposes draft Releases only to push-capable identities. Consequently,
+the release-resolution job and the pre-PyPI revalidation job each need
+job-scoped `contents: write` even though their release operations are reads.
+The workflow default, canonical verifier, real-container gate, and build job
+remain `contents: read`; the GitHub finalization job already needs write access
+for attachment and publication. Checkouts in either write-scoped job must not
+persist the elevated credential, and the permission correction must not
+introduce a PAT or long-lived publication secret.
+
 Nothing is hand-run, and feature PRs never touch `CHANGELOG.md` (release-please
 owns it) — no fragment collisions.
 
@@ -117,6 +126,10 @@ checks, exact wheel and sdist installation/conformance smokes, and OIDC
 publication chain. PyPI upload and GitHub attachment are separate jobs, so use
 GitHub's **re-run failed jobs** operation if attachment or finalization fails
 after PyPI succeeds.
+For a draft created by an older run that failed before PyPI publication, invoke
+the current workflow from the default branch with that existing tag rather than
+re-running the stale workflow definition. This preserves the bound tag, commit,
+and numeric Release identity while applying the current publication gates.
 Manual dispatch is not a verification bypass and never builds from the current
 branch head.
 
@@ -142,9 +155,11 @@ token stored):
 > must match or only the PyPI publish step 403s.
 
 The `pypi` environment and `id-token: write` permission exist only on the PyPI
-upload job. Configure that environment's deployment branch policy for `main`.
-Resolution, canonical verification, distribution installation, GitHub
-attachment, and CLI execution cannot mint the PyPI publishing credential.
+upload job. That job also has job-scoped `contents: write` solely so its
+post-approval identity check can see the still-draft GitHub Release. Configure
+the environment's deployment branch policy for `main`. Resolution, canonical
+verification, distribution installation, GitHub attachment, and CLI execution
+cannot mint the PyPI publishing credential.
 
 ## Pinning from a downstream backend
 

--- a/implementations/python/tests/test_release_workflows.py
+++ b/implementations/python/tests/test_release_workflows.py
@@ -24,6 +24,7 @@ DOCKER_INTEGRATION_PATH = (
 
 LOCAL_CANONICAL_WORKFLOW = "./.github/workflows/canonical-verification.yml"
 FULL_SHA_USE = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+DRAFT_RELEASE_STATE = re.compile(r"(?:\bisDraft\b|\.(?:isDraft|draft)\b|-F\s+draft=)")
 
 
 def _load(path: Path) -> dict[str, Any]:
@@ -112,6 +113,8 @@ def _run_github_finalization(
     *,
     release_states: list[str],
     mismatched_download: bool = False,
+    moved_tag: bool = False,
+    finalization_json: str = '{"id":1234,"tag_name":"v3.4.5","draft":false}',
 ) -> subprocess.CompletedProcess[str]:
     if shutil.which("bash") is None or shutil.which("jq") is None:
         pytest.skip("the release finalization shell policy requires bash and jq")
@@ -164,7 +167,7 @@ case "${1-}:${2-}" in
     ;;
   api:*)
     printf '%s\n' patch >> "$CALL_LOG"
-    printf '%s\n' '{"id":1234,"tag_name":"v3.4.5","draft":false}'
+    printf '%s\n' "$FINALIZATION_JSON"
     ;;
   *)
     echo "unexpected gh request: $*" >&2
@@ -183,7 +186,7 @@ set -eu
 case "${1-}:${2-}" in
   fetch:*) exit 0 ;;
   rev-parse:HEAD) printf '%s\n' "$EXPECTED_SHA" ;;
-  rev-parse:--verify) printf '%s\n' "$EXPECTED_SHA" ;;
+  rev-parse:--verify) printf '%s\n' "$ACTUAL_TAG_SHA" ;;
   *) echo "unexpected git request: $*" >&2; exit 64 ;;
 esac
 """,
@@ -198,6 +201,7 @@ esac
         "GITHUB_REPOSITORY": "OpenRAE/rae",
         "RUNNER_TEMP": str(tmp_path),
         "EXPECTED_SHA": "a" * 40,
+        "ACTUAL_TAG_SHA": ("c" if moved_tag else "a") * 40,
         "EXPECTED_TAG": "v3.4.5",
         "EXPECTED_RELEASE_ID": "1234",
         "EXPECTED_DRAFT": "true",
@@ -206,6 +210,7 @@ esac
         "CALL_LOG": str(call_log),
         "TEST_DIST_SOURCE": str(dist),
         "MISMATCH_DOWNLOAD": "1" if mismatched_download else "0",
+        "FINALIZATION_JSON": finalization_json,
     }
     return subprocess.run(
         ["bash", "-c", script],
@@ -317,10 +322,13 @@ def test_release_resolves_and_verifies_one_immutable_release_commit() -> None:
     resolve = jobs["resolve-release"]
     assert resolve["needs"] == "release-please"
     assert "github.event_name == 'push'" in resolve["if"]
+    assert "github.event_name == 'workflow_dispatch'" in resolve["if"]
     assert "needs.release-please.result == 'success'" in resolve["if"]
     assert "needs.release-please.outputs.release_created == 'true'" in resolve["if"]
-    assert resolve["permissions"] == {"contents": "read"}
+    assert resolve["permissions"] == {"contents": "write"}
     resolution = _named_step(resolve, "Resolve and bind the immutable release commit")["run"]
+    assert 'if [ "${EVENT_NAME}" = "workflow_dispatch" ]' in resolution
+    assert 'tag="${INPUT_TAG}"' in resolution
     assert 'expected_sha="${RELEASE_PLEASE_SHA}"' in resolution
     assert 'tag_sha="$(git rev-parse --verify "${tag}^{commit}")"' in resolution
     assert '"${tag_sha}" != "${expected_sha}"' in resolution
@@ -335,6 +343,35 @@ def test_release_resolves_and_verifies_one_immutable_release_commit() -> None:
     assert verify["uses"] == LOCAL_CANONICAL_WORKFLOW
     assert verify["with"]["ref"] == "${{ needs.resolve-release.outputs.release_sha }}"
     assert verify["with"]["base-rev"] == "${{ needs.resolve-release.outputs.base_sha }}"
+
+
+def test_every_shell_draft_release_inspection_has_push_capable_token() -> None:
+    workflow = _load(RELEASE_PATH)
+    assert workflow["permissions"] == {"contents": "read"}
+
+    draft_inspection_jobs = {
+        name
+        for name, job in workflow["jobs"].items()
+        if any(DRAFT_RELEASE_STATE.search(step.get("run", "")) for step in job.get("steps", []))
+    }
+    assert draft_inspection_jobs
+    insufficient_permissions = {
+        name
+        for name in draft_inspection_jobs
+        if workflow["jobs"][name].get("permissions", {}).get("contents") != "write"
+    }
+    assert not insufficient_permissions, (
+        f"draft GitHub Releases require push-capable contents permission: {sorted(insufficient_permissions)}"
+    )
+
+    for name, job in workflow["jobs"].items():
+        if job.get("permissions", {}).get("contents") != "write":
+            continue
+        for step in job.get("steps", []):
+            if step.get("uses", "").startswith("actions/checkout@"):
+                assert step.get("with", {}).get("persist-credentials") is False, (
+                    f"{name} must not persist its write-scoped checkout credential"
+                )
 
 
 def test_release_builds_and_smokes_the_verified_sha_before_publish() -> None:
@@ -422,7 +459,7 @@ def test_publication_is_split_retry_safe_and_finalizes_the_same_release() -> Non
     assert "needs.integration-docker-release.result == 'success'" in publish_pypi["if"]
     assert "needs.build-release.result == 'success'" in publish_pypi["if"]
     assert publish_pypi["environment"] == "pypi"
-    assert publish_pypi["permissions"] == {"contents": "read", "id-token": "write"}
+    assert publish_pypi["permissions"] == {"contents": "write", "id-token": "write"}
 
     for name, job in jobs.items():
         if name == "publish-pypi":
@@ -528,6 +565,36 @@ def test_github_finalization_revalidates_release_object_after_attachment(tmp_pat
     assert result.returncode != 0
     assert "Release identity changed during attachment; refusing public finalization" in result.stderr
     assert (tmp_path / "gh-calls.log").read_text(encoding="utf-8").splitlines() == ["upload"]
+
+
+def test_github_finalization_rejects_moved_tag_before_attachment(tmp_path: Path) -> None:
+    result = _run_github_finalization(
+        tmp_path,
+        release_states=['{"databaseId":1234,"isDraft":true,"tagName":"v3.4.5"}'],
+        moved_tag=True,
+    )
+
+    assert result.returncode != 0
+    assert f"Release tag moved: expected {'a' * 40}, got {'c' * 40}" in result.stderr
+    assert not (tmp_path / "gh-calls.log").exists()
+
+
+def test_github_finalization_rejects_tampered_finalization_response(tmp_path: Path) -> None:
+    result = _run_github_finalization(
+        tmp_path,
+        release_states=[
+            '{"databaseId":1234,"isDraft":true,"tagName":"v3.4.5"}',
+            '{"databaseId":1234,"isDraft":true,"tagName":"v3.4.5"}',
+        ],
+        finalization_json='{"id":9999,"tag_name":"v3.4.5","draft":false}',
+    )
+
+    assert result.returncode != 0
+    assert "GitHub Release finalization response changed the verified identity" in result.stderr
+    assert (tmp_path / "gh-calls.log").read_text(encoding="utf-8").splitlines() == [
+        "upload",
+        "patch",
+    ]
 
 
 def test_github_finalization_uses_bound_id_and_accepts_verified_response(tmp_path: Path) -> None:


### PR DESCRIPTION
## Plain-Language Summary

- **Context:** The release workflow keeps GitHub Releases as drafts while the exact tagged commit passes canonical verification, container testing, artifact smokes, PyPI publication, and final identity checks.
- **Problem:** GitHub hides draft Releases from read-only tokens, so release resolution and the pre-PyPI identity check fail before the guarded publication graph can complete.
- **Fix:** Give only draft-inspecting jobs push-capable contents permission, prevent elevated checkout credentials from persisting, and enforce the boundary with data-driven and executable regression tests.

## Issue Tracking

Closes #1190

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## ADR Impact

- ADR-021

## Changes

- Grant job-scoped contents write permission to release resolution and pre-PyPI draft revalidation while retaining the read-only workflow default.
- Disable persisted checkout credentials in write-scoped checkout jobs and keep the PyPI publisher checkout-free with step-local GitHub token binding.
- Add data-driven draft-lookup permission coverage plus executable moved-tag and tampered-finalization-response regressions, and update release architecture and recovery guidance.

## Verification

- `pytest implementations/python/tests/test_release_workflows.py -q`: 19 passed.
- Configured repository completion and policy gates: passed after final review fixes.
- Mandatory pre-commit and synchronized-base verification: passed.
- Pre-push engineering review: clean; test-quality finding fixed and dispositioned per the recorded user direction.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: Issue #1190 ← .github/workflows/release-please.yml, Issue #1190 ← docs/explain/releasing.md
- TESTS: Issue #1190 ← implementations/python/tests/test_release_workflows.py

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog is owned by Release Please; no per-PR fragment is added
- [x] Architectural and operator documentation is updated

## Documentation

Updated the exact-SHA release decision note and the operator release/recovery guide.

## Notes for Review

The workflow default and all verification/build jobs remain read-only. The PyPI job remains checkout-free and is still the only holder of OIDC publication authority.
