### PR TITLE
feat(sdl): add typed package repository profiles

### DIFF
--- a/contracts/fixtures/sdl/runtime-package-repository-v1/README.md
+++ b/contracts/fixtures/sdl/runtime-package-repository-v1/README.md
@@ -1,0 +1,6 @@
+# Runtime package repository profile fixtures
+
+These fixtures exercise the portable APT repository profile introduced for
+issue #847. The valid case pins the exact public signing-key bytes; the invalid
+case demonstrates that an HTTPS key locator without its mandatory SHA-256
+digest is not an exact trust binding.

--- a/contracts/fixtures/sdl/runtime-package-repository-v1/invalid/unpinned-key.yaml
+++ b/contracts/fixtures/sdl/runtime-package-repository-v1/invalid/unpinned-key.yaml
@@ -1,0 +1,20 @@
+name: unpinned-third-party-repository-key
+nodes:
+  manager:
+    type: compute
+    os: linux
+    resources: {ram: 1 gib, cpu: 1}
+    runtime:
+      packages:
+        - manager: apt
+          name: wazuh-agent
+          version: 4.12.0-1
+          repository:
+            repository_profile: apt
+            profile_version: "1"
+            uri: https://packages.wazuh.com/4.x/apt/
+            suite: stable
+            components: [main]
+            signing_key:
+              uri: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+              format: openpgp-ascii-armored

--- a/contracts/fixtures/sdl/runtime-package-repository-v1/valid/wazuh.yaml
+++ b/contracts/fixtures/sdl/runtime-package-repository-v1/valid/wazuh.yaml
@@ -1,0 +1,21 @@
+name: wazuh-third-party-repository
+nodes:
+  manager:
+    type: compute
+    os: linux
+    resources: {ram: 1 gib, cpu: 1}
+    runtime:
+      packages:
+        - manager: apt
+          name: wazuh-agent
+          version: 4.12.0-1
+          repository:
+            repository_profile: apt
+            profile_version: "1"
+            uri: https://packages.wazuh.com/4.x/apt/
+            suite: stable
+            components: [main]
+            signing_key:
+              uri: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+              format: openpgp-ascii-armored
+              digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/contracts/schema-publication/entries/instantiated-scenario-snapshot-v1.json
+++ b/contracts/schema-publication/entries/instantiated-scenario-snapshot-v1.json
@@ -2,9 +2,9 @@
   "contract_id": "instantiated-scenario-snapshot-v1",
   "schema_path": "contracts/schemas/sdl/instantiated-scenario-snapshot-v1.json",
   "stability": "draft",
-  "content_hash": "4339c86ad1ec1a43ee2c0bb027d2e26ff9e171a37215e38a17ba262e6efadc57",
+  "content_hash": "f422afb4d7282b817fdc3cfe17fd99d72f708f08b42bcc56615b9fa834c44a2b",
   "last_change": {
-    "summary": "Added generated-artifact output environment consumption for issue #1074 and DSL-435 alongside participant-interaction commutativity and merge rules from issue #1101.",
-    "content_hash": "4339c86ad1ec1a43ee2c0bb027d2e26ff9e171a37215e38a17ba262e6efadc57"
+    "summary": "Added the closed, SHA-256-pinned APT runtime package repository profile for issue #847.",
+    "content_hash": "f422afb4d7282b817fdc3cfe17fd99d72f708f08b42bcc56615b9fa834c44a2b"
   }
 }

--- a/contracts/schema-publication/entries/instantiated-scenario-v1.json
+++ b/contracts/schema-publication/entries/instantiated-scenario-v1.json
@@ -2,9 +2,9 @@
   "contract_id": "instantiated-scenario-v1",
   "schema_path": "contracts/schemas/sdl/instantiated-scenario-v1.json",
   "stability": "draft",
-  "content_hash": "ba0268a9ee8cc21377ca65ade9c90624d7d2687c24ce643eecb55de1805a2d22",
+  "content_hash": "ad443145c32851ee2dadba948a552c8bf99f2dfc6a72545aea4b2b7577a972f9",
   "last_change": {
-    "summary": "Added generated-artifact output environment consumption for issue #1074 and DSL-435 alongside participant-interaction commutativity and merge rules from issue #1101.",
-    "content_hash": "ba0268a9ee8cc21377ca65ade9c90624d7d2687c24ce643eecb55de1805a2d22"
+    "summary": "Added the closed, SHA-256-pinned APT runtime package repository profile for issue #847.",
+    "content_hash": "ad443145c32851ee2dadba948a552c8bf99f2dfc6a72545aea4b2b7577a972f9"
   }
 }

--- a/contracts/schema-publication/entries/scenario-satisfiability-evidence-v1.json
+++ b/contracts/schema-publication/entries/scenario-satisfiability-evidence-v1.json
@@ -2,9 +2,9 @@
   "contract_id": "scenario-satisfiability-evidence-v1",
   "schema_path": "contracts/schemas/satisfiability/scenario-satisfiability-evidence-v1.json",
   "stability": "draft",
-  "content_hash": "2981c2cb86232160373a380a20fbb1ad7d69b09628095e6d05979e397f4446a7",
+  "content_hash": "d08e616869e52a2e533b49344827b161eb8d9d908f9c8c5ad61081f203bc4fe2",
   "last_change": {
-    "summary": "Added generated-artifact output environment consumption for issue #1074 and DSL-435 alongside participant-interaction commutativity and merge rules from issue #1101.",
-    "content_hash": "2981c2cb86232160373a380a20fbb1ad7d69b09628095e6d05979e397f4446a7"
+    "summary": "Added the closed, SHA-256-pinned APT runtime package repository profile for issue #847.",
+    "content_hash": "d08e616869e52a2e533b49344827b161eb8d9d908f9c8c5ad61081f203bc4fe2"
   }
 }

--- a/contracts/schema-publication/entries/sdl-authoring-input-v1.json
+++ b/contracts/schema-publication/entries/sdl-authoring-input-v1.json
@@ -2,9 +2,9 @@
   "contract_id": "sdl-authoring-input-v1",
   "schema_path": "contracts/schemas/sdl/sdl-authoring-input-v1.json",
   "stability": "draft",
-  "content_hash": "b8da44157c074c3790eb8651e9102b9a7ad067f5e4e4da4b04cb9ddc78029003",
+  "content_hash": "2a6f907c65d3b40051f3a38604607f0d57d0b6f277ea38c167eae6c2c7b750ac",
   "last_change": {
-    "summary": "Added generated-artifact output environment consumption for issue #1074 and DSL-435 alongside participant-interaction commutativity and merge rules from issue #1101.",
-    "content_hash": "b8da44157c074c3790eb8651e9102b9a7ad067f5e4e4da4b04cb9ddc78029003"
+    "summary": "Added the closed, SHA-256-pinned APT runtime package repository profile for issue #847.",
+    "content_hash": "2a6f907c65d3b40051f3a38604607f0d57d0b6f277ea38c167eae6c2c7b750ac"
   }
 }

--- a/contracts/schemas/satisfiability/scenario-satisfiability-evidence-v1.json
+++ b/contracts/schemas/satisfiability/scenario-satisfiability-evidence-v1.json
@@ -13154,6 +13154,86 @@
       "title": "RuntimeApplicationSurface",
       "type": "object"
     },
+    "RuntimeAptPackageRepository": {
+      "additionalProperties": false,
+      "description": "Version 1 portable binary APT repository and dedicated trust binding.",
+      "properties": {
+        "components": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "not": {
+              "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+            },
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9.+_~-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 32,
+          "minItems": 1,
+          "title": "Components",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "profile_version": {
+          "const": "1",
+          "title": "Profile Version",
+          "type": "string"
+        },
+        "repository_profile": {
+          "const": "apt",
+          "title": "Repository Profile",
+          "type": "string"
+        },
+        "signing_key": {
+          "$ref": "#/$defs/RuntimePackageRepositorySigningKey"
+        },
+        "suite": {
+          "maxLength": 128,
+          "minLength": 1,
+          "not": {
+            "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+          },
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9.+_~:-]{0,127}$",
+          "title": "Suite",
+          "type": "string"
+        },
+        "uri": {
+          "allOf": [
+            {
+              "not": {
+                "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+              }
+            }
+          ],
+          "description": "Credential-free HTTPS base URI of the binary APT repository.",
+          "maxLength": 2048,
+          "minLength": 1,
+          "not": {
+            "anyOf": [
+              {
+                "pattern": "^https://[^/?#]*@"
+              },
+              {
+                "pattern": "[?&](?:access_token|api_key|apikey|auth|credential|key|password|secret|sig|signature|token)(?:=|&|$)"
+              }
+            ]
+          },
+          "pattern": "^https://[^\\s#]+$",
+          "title": "Uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository_profile",
+        "profile_version",
+        "uri",
+        "suite",
+        "components",
+        "signing_key"
+      ],
+      "title": "RuntimeAptPackageRepository",
+      "type": "object"
+    },
     "RuntimeCapabilityOverrideScope": {
       "description": "Scope of a ``RuntimeProcessCapabilityOverride``.\n\n``PROCESS`` records a capability delta that applies only to the subject\nprocess itself; ``SUBTREE`` records a delta that applies to the subject\nprocess and every descendant it spawns (the motivating case is\n``capsh --drop=cap_audit_control`` exec'ing ``sshd``, after which the\ninteractive shell subtree runs without ``CAP_AUDIT_CONTROL``).",
       "enum": [
@@ -21763,7 +21843,50 @@
     },
     "RuntimePackage": {
       "additionalProperties": false,
-      "description": "A package required in a runtime image or node.",
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "repository": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "repository"
+            ]
+          },
+          "then": {
+            "properties": {
+              "manager": {
+                "const": "apt"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "pattern": "^[a-z0-9][a-z0-9+.-]{0,127}$"
+                  },
+                  {
+                    "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$"
+                  }
+                ]
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "pattern": "^[0-9][A-Za-z0-9.+:~_-]{0,255}$"
+                  },
+                  {
+                    "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "description": "An exact package required in a runtime image or node.\n\n``repository`` is absent for ordinary target-configured repositories. When\npresent, it is required final node state and stays within the existing\n``runtime-packages`` realization concern.",
       "properties": {
         "architecture": {
           "default": "",
@@ -21775,6 +21898,7 @@
           "type": "string"
         },
         "manager": {
+          "description": "Package manager identity used by the target node.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -21782,6 +21906,7 @@
           "type": "string"
         },
         "name": {
+          "description": "Package name interpreted by the selected package manager.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -21790,14 +21915,39 @@
         },
         "purl": {
           "default": "",
+          "description": "Package URL identity metadata; never a repository locator, trust binding, or acquisition command.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
           "title": "Purl",
           "type": "string"
         },
+        "repository": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "apt": "#/$defs/RuntimeAptPackageRepository"
+                },
+                "propertyName": "repository_profile"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/RuntimeAptPackageRepository"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Closed third-party repository profile; absence selects the target's ordinary configured sources.",
+          "title": "Repository"
+        },
         "source": {
           "default": "",
+          "description": "Opaque package source or provenance label; never a repository declaration or executable value.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -21805,6 +21955,7 @@
           "type": "string"
         },
         "version": {
+          "description": "Exact package version interpreted by the selected package manager.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -21818,6 +21969,61 @@
         "version"
       ],
       "title": "RuntimePackage",
+      "type": "object"
+    },
+    "RuntimePackageRepositorySigningKey": {
+      "additionalProperties": false,
+      "description": "Exact public OpenPGP key bytes trusted by one package repository.",
+      "properties": {
+        "digest": {
+          "description": "Canonical SHA-256 digest of the exact public signing-key bytes.",
+          "not": {
+            "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+          },
+          "pattern": "^(?:sha256:[a-f0-9]{64}|\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\})$",
+          "title": "Digest",
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "openpgp-ascii-armored",
+            "openpgp-binary"
+          ],
+          "title": "Format",
+          "type": "string"
+        },
+        "uri": {
+          "allOf": [
+            {
+              "not": {
+                "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+              }
+            }
+          ],
+          "description": "Credential-free HTTPS location of the public signing-key bytes.",
+          "maxLength": 2048,
+          "minLength": 1,
+          "not": {
+            "anyOf": [
+              {
+                "pattern": "^https://[^/?#]*@"
+              },
+              {
+                "pattern": "[?&](?:access_token|api_key|apikey|auth|credential|key|password|secret|sig|signature|token)(?:=|&|$)"
+              }
+            ]
+          },
+          "pattern": "^https://[^\\s#]+$",
+          "title": "Uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri",
+        "format",
+        "digest"
+      ],
+      "title": "RuntimePackageRepositorySigningKey",
       "type": "object"
     },
     "RuntimePlatformApplication": {

--- a/contracts/schemas/sdl/instantiated-scenario-snapshot-v1.json
+++ b/contracts/schemas/sdl/instantiated-scenario-snapshot-v1.json
@@ -13307,6 +13307,86 @@
       "title": "RuntimeApplicationSurface",
       "type": "object"
     },
+    "RuntimeAptPackageRepository": {
+      "additionalProperties": false,
+      "description": "Version 1 portable binary APT repository and dedicated trust binding.",
+      "properties": {
+        "components": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "not": {
+              "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+            },
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9.+_~-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 32,
+          "minItems": 1,
+          "title": "Components",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "profile_version": {
+          "const": "1",
+          "title": "Profile Version",
+          "type": "string"
+        },
+        "repository_profile": {
+          "const": "apt",
+          "title": "Repository Profile",
+          "type": "string"
+        },
+        "signing_key": {
+          "$ref": "#/$defs/RuntimePackageRepositorySigningKey"
+        },
+        "suite": {
+          "maxLength": 128,
+          "minLength": 1,
+          "not": {
+            "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+          },
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9.+_~:-]{0,127}$",
+          "title": "Suite",
+          "type": "string"
+        },
+        "uri": {
+          "allOf": [
+            {
+              "not": {
+                "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+              }
+            }
+          ],
+          "description": "Credential-free HTTPS base URI of the binary APT repository.",
+          "maxLength": 2048,
+          "minLength": 1,
+          "not": {
+            "anyOf": [
+              {
+                "pattern": "^https://[^/?#]*@"
+              },
+              {
+                "pattern": "[?&](?:access_token|api_key|apikey|auth|credential|key|password|secret|sig|signature|token)(?:=|&|$)"
+              }
+            ]
+          },
+          "pattern": "^https://[^\\s#]+$",
+          "title": "Uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository_profile",
+        "profile_version",
+        "uri",
+        "suite",
+        "components",
+        "signing_key"
+      ],
+      "title": "RuntimeAptPackageRepository",
+      "type": "object"
+    },
     "RuntimeCapabilityOverrideScope": {
       "description": "Scope of a ``RuntimeProcessCapabilityOverride``.\n\n``PROCESS`` records a capability delta that applies only to the subject\nprocess itself; ``SUBTREE`` records a delta that applies to the subject\nprocess and every descendant it spawns (the motivating case is\n``capsh --drop=cap_audit_control`` exec'ing ``sshd``, after which the\ninteractive shell subtree runs without ``CAP_AUDIT_CONTROL``).",
       "enum": [
@@ -22337,7 +22417,50 @@
     },
     "RuntimePackage": {
       "additionalProperties": false,
-      "description": "A package required in a runtime image or node.",
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "repository": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "repository"
+            ]
+          },
+          "then": {
+            "properties": {
+              "manager": {
+                "const": "apt"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "pattern": "^[a-z0-9][a-z0-9+.-]{0,127}$"
+                  },
+                  {
+                    "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$"
+                  }
+                ]
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "pattern": "^[0-9][A-Za-z0-9.+:~_-]{0,255}$"
+                  },
+                  {
+                    "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "description": "An exact package required in a runtime image or node.\n\n``repository`` is absent for ordinary target-configured repositories. When\npresent, it is required final node state and stays within the existing\n``runtime-packages`` realization concern.",
       "properties": {
         "architecture": {
           "default": "",
@@ -22349,6 +22472,7 @@
           "type": "string"
         },
         "manager": {
+          "description": "Package manager identity used by the target node.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -22356,6 +22480,7 @@
           "type": "string"
         },
         "name": {
+          "description": "Package name interpreted by the selected package manager.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -22364,14 +22489,39 @@
         },
         "purl": {
           "default": "",
+          "description": "Package URL identity metadata; never a repository locator, trust binding, or acquisition command.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
           "title": "Purl",
           "type": "string"
         },
+        "repository": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "apt": "#/$defs/RuntimeAptPackageRepository"
+                },
+                "propertyName": "repository_profile"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/RuntimeAptPackageRepository"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Closed third-party repository profile; absence selects the target's ordinary configured sources.",
+          "title": "Repository"
+        },
         "source": {
           "default": "",
+          "description": "Opaque package source or provenance label; never a repository declaration or executable value.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -22379,6 +22529,7 @@
           "type": "string"
         },
         "version": {
+          "description": "Exact package version interpreted by the selected package manager.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -22392,6 +22543,61 @@
         "version"
       ],
       "title": "RuntimePackage",
+      "type": "object"
+    },
+    "RuntimePackageRepositorySigningKey": {
+      "additionalProperties": false,
+      "description": "Exact public OpenPGP key bytes trusted by one package repository.",
+      "properties": {
+        "digest": {
+          "description": "Canonical SHA-256 digest of the exact public signing-key bytes.",
+          "not": {
+            "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+          },
+          "pattern": "^(?:sha256:[a-f0-9]{64}|\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\})$",
+          "title": "Digest",
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "openpgp-ascii-armored",
+            "openpgp-binary"
+          ],
+          "title": "Format",
+          "type": "string"
+        },
+        "uri": {
+          "allOf": [
+            {
+              "not": {
+                "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+              }
+            }
+          ],
+          "description": "Credential-free HTTPS location of the public signing-key bytes.",
+          "maxLength": 2048,
+          "minLength": 1,
+          "not": {
+            "anyOf": [
+              {
+                "pattern": "^https://[^/?#]*@"
+              },
+              {
+                "pattern": "[?&](?:access_token|api_key|apikey|auth|credential|key|password|secret|sig|signature|token)(?:=|&|$)"
+              }
+            ]
+          },
+          "pattern": "^https://[^\\s#]+$",
+          "title": "Uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri",
+        "format",
+        "digest"
+      ],
+      "title": "RuntimePackageRepositorySigningKey",
       "type": "object"
     },
     "RuntimePlatformApplication": {

--- a/contracts/schemas/sdl/instantiated-scenario-v1.json
+++ b/contracts/schemas/sdl/instantiated-scenario-v1.json
@@ -12664,6 +12664,86 @@
       "title": "RuntimeApplicationSurface",
       "type": "object"
     },
+    "RuntimeAptPackageRepository": {
+      "additionalProperties": false,
+      "description": "Version 1 portable binary APT repository and dedicated trust binding.",
+      "properties": {
+        "components": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "not": {
+              "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+            },
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9.+_~-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 32,
+          "minItems": 1,
+          "title": "Components",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "profile_version": {
+          "const": "1",
+          "title": "Profile Version",
+          "type": "string"
+        },
+        "repository_profile": {
+          "const": "apt",
+          "title": "Repository Profile",
+          "type": "string"
+        },
+        "signing_key": {
+          "$ref": "#/$defs/RuntimePackageRepositorySigningKey"
+        },
+        "suite": {
+          "maxLength": 128,
+          "minLength": 1,
+          "not": {
+            "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+          },
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9.+_~:-]{0,127}$",
+          "title": "Suite",
+          "type": "string"
+        },
+        "uri": {
+          "allOf": [
+            {
+              "not": {
+                "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+              }
+            }
+          ],
+          "description": "Credential-free HTTPS base URI of the binary APT repository.",
+          "maxLength": 2048,
+          "minLength": 1,
+          "not": {
+            "anyOf": [
+              {
+                "pattern": "^https://[^/?#]*@"
+              },
+              {
+                "pattern": "[?&](?:access_token|api_key|apikey|auth|credential|key|password|secret|sig|signature|token)(?:=|&|$)"
+              }
+            ]
+          },
+          "pattern": "^https://[^\\s#]+$",
+          "title": "Uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository_profile",
+        "profile_version",
+        "uri",
+        "suite",
+        "components",
+        "signing_key"
+      ],
+      "title": "RuntimeAptPackageRepository",
+      "type": "object"
+    },
     "RuntimeCapabilityOverrideScope": {
       "description": "Scope of a ``RuntimeProcessCapabilityOverride``.\n\n``PROCESS`` records a capability delta that applies only to the subject\nprocess itself; ``SUBTREE`` records a delta that applies to the subject\nprocess and every descendant it spawns (the motivating case is\n``capsh --drop=cap_audit_control`` exec'ing ``sshd``, after which the\ninteractive shell subtree runs without ``CAP_AUDIT_CONTROL``).",
       "enum": [
@@ -21694,7 +21774,50 @@
     },
     "RuntimePackage": {
       "additionalProperties": false,
-      "description": "A package required in a runtime image or node.",
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "repository": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "repository"
+            ]
+          },
+          "then": {
+            "properties": {
+              "manager": {
+                "const": "apt"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "pattern": "^[a-z0-9][a-z0-9+.-]{0,127}$"
+                  },
+                  {
+                    "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$"
+                  }
+                ]
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "pattern": "^[0-9][A-Za-z0-9.+:~_-]{0,255}$"
+                  },
+                  {
+                    "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "description": "An exact package required in a runtime image or node.\n\n``repository`` is absent for ordinary target-configured repositories. When\npresent, it is required final node state and stays within the existing\n``runtime-packages`` realization concern.",
       "properties": {
         "architecture": {
           "default": "",
@@ -21706,6 +21829,7 @@
           "type": "string"
         },
         "manager": {
+          "description": "Package manager identity used by the target node.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -21713,6 +21837,7 @@
           "type": "string"
         },
         "name": {
+          "description": "Package name interpreted by the selected package manager.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -21721,14 +21846,39 @@
         },
         "purl": {
           "default": "",
+          "description": "Package URL identity metadata; never a repository locator, trust binding, or acquisition command.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
           "title": "Purl",
           "type": "string"
         },
+        "repository": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "apt": "#/$defs/RuntimeAptPackageRepository"
+                },
+                "propertyName": "repository_profile"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/RuntimeAptPackageRepository"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Closed third-party repository profile; absence selects the target's ordinary configured sources.",
+          "title": "Repository"
+        },
         "source": {
           "default": "",
+          "description": "Opaque package source or provenance label; never a repository declaration or executable value.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -21736,6 +21886,7 @@
           "type": "string"
         },
         "version": {
+          "description": "Exact package version interpreted by the selected package manager.",
           "not": {
             "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
           },
@@ -21749,6 +21900,61 @@
         "version"
       ],
       "title": "RuntimePackage",
+      "type": "object"
+    },
+    "RuntimePackageRepositorySigningKey": {
+      "additionalProperties": false,
+      "description": "Exact public OpenPGP key bytes trusted by one package repository.",
+      "properties": {
+        "digest": {
+          "description": "Canonical SHA-256 digest of the exact public signing-key bytes.",
+          "not": {
+            "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+          },
+          "pattern": "^(?:sha256:[a-f0-9]{64}|\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\})$",
+          "title": "Digest",
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "openpgp-ascii-armored",
+            "openpgp-binary"
+          ],
+          "title": "Format",
+          "type": "string"
+        },
+        "uri": {
+          "allOf": [
+            {
+              "not": {
+                "pattern": "\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}"
+              }
+            }
+          ],
+          "description": "Credential-free HTTPS location of the public signing-key bytes.",
+          "maxLength": 2048,
+          "minLength": 1,
+          "not": {
+            "anyOf": [
+              {
+                "pattern": "^https://[^/?#]*@"
+              },
+              {
+                "pattern": "[?&](?:access_token|api_key|apikey|auth|credential|key|password|secret|sig|signature|token)(?:=|&|$)"
+              }
+            ]
+          },
+          "pattern": "^https://[^\\s#]+$",
+          "title": "Uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri",
+        "format",
+        "digest"
+      ],
+      "title": "RuntimePackageRepositorySigningKey",
       "type": "object"
     },
     "RuntimePlatformApplication": {

--- a/contracts/schemas/sdl/sdl-authoring-input-v1.json
+++ b/contracts/schemas/sdl/sdl-authoring-input-v1.json
@@ -10838,6 +10838,82 @@
       "title": "RuntimeApplicationSurface",
       "type": "object"
     },
+    "RuntimeAptPackageRepository": {
+      "additionalProperties": false,
+      "description": "Version 1 portable binary APT repository and dedicated trust binding.",
+      "properties": {
+        "components": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9.+_~-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 32,
+          "minItems": 1,
+          "title": "Components",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "profile_version": {
+          "const": "1",
+          "title": "Profile Version",
+          "type": "string"
+        },
+        "repository_profile": {
+          "const": "apt",
+          "title": "Repository Profile",
+          "type": "string"
+        },
+        "signing_key": {
+          "$ref": "#/$defs/RuntimePackageRepositorySigningKey"
+        },
+        "suite": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9.+_~:-]{0,127}$",
+          "title": "Suite",
+          "type": "string"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "not": {
+                "anyOf": [
+                  {
+                    "pattern": "^https://[^/?#]*@"
+                  },
+                  {
+                    "pattern": "[?&](?:access_token|api_key|apikey|auth|credential|key|password|secret|sig|signature|token)(?:=|&|$)"
+                  }
+                ]
+              },
+              "pattern": "^https://[^\\s#]+$",
+              "type": "string"
+            },
+            {
+              "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$",
+              "type": "string",
+              "x-raes-variable-reference": true
+            }
+          ],
+          "description": "Credential-free HTTPS base URI of the binary APT repository.",
+          "title": "Uri"
+        }
+      },
+      "required": [
+        "repository_profile",
+        "profile_version",
+        "uri",
+        "suite",
+        "components",
+        "signing_key"
+      ],
+      "title": "RuntimeAptPackageRepository",
+      "type": "object"
+    },
     "RuntimeCapabilityOverrideScope": {
       "description": "Scope of a ``RuntimeProcessCapabilityOverride``.\n\n``PROCESS`` records a capability delta that applies only to the subject\nprocess itself; ``SUBTREE`` records a delta that applies to the subject\nprocess and every descendant it spawns (the motivating case is\n``capsh --drop=cap_audit_control`` exec'ing ``sshd``, after which the\ninteractive shell subtree runs without ``CAP_AUDIT_CONTROL``).",
       "enum": [
@@ -18079,7 +18155,50 @@
     },
     "RuntimePackage": {
       "additionalProperties": false,
-      "description": "A package required in a runtime image or node.",
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "repository": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "repository"
+            ]
+          },
+          "then": {
+            "properties": {
+              "manager": {
+                "const": "apt"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "pattern": "^[a-z0-9][a-z0-9+.-]{0,127}$"
+                  },
+                  {
+                    "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$"
+                  }
+                ]
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "pattern": "^[0-9][A-Za-z0-9.+:~_-]{0,255}$"
+                  },
+                  {
+                    "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "description": "An exact package required in a runtime image or node.\n\n``repository`` is absent for ordinary target-configured repositories. When\npresent, it is required final node state and stays within the existing\n``runtime-packages`` realization concern.",
       "properties": {
         "architecture": {
           "default": "",
@@ -18088,24 +18207,52 @@
           "type": "string"
         },
         "manager": {
+          "description": "Package manager identity used by the target node.",
           "title": "Manager",
           "type": "string"
         },
         "name": {
+          "description": "Package name interpreted by the selected package manager.",
           "title": "Name",
           "type": "string"
         },
         "purl": {
           "default": "",
+          "description": "Package URL identity metadata; never a repository locator, trust binding, or acquisition command.",
           "title": "Purl",
           "type": "string"
         },
+        "repository": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "apt": "#/$defs/RuntimeAptPackageRepository"
+                },
+                "propertyName": "repository_profile"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/RuntimeAptPackageRepository"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Closed third-party repository profile; absence selects the target's ordinary configured sources.",
+          "title": "Repository"
+        },
         "source": {
           "default": "",
+          "description": "Opaque package source or provenance label; never a repository declaration or executable value.",
           "title": "Source",
           "type": "string"
         },
         "version": {
+          "description": "Exact package version interpreted by the selected package manager.",
           "title": "Version",
           "type": "string"
         }
@@ -18116,6 +18263,60 @@
         "version"
       ],
       "title": "RuntimePackage",
+      "type": "object"
+    },
+    "RuntimePackageRepositorySigningKey": {
+      "additionalProperties": false,
+      "description": "Exact public OpenPGP key bytes trusted by one package repository.",
+      "properties": {
+        "digest": {
+          "description": "Canonical SHA-256 digest of the exact public signing-key bytes.",
+          "pattern": "^(?:sha256:[a-f0-9]{64}|\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\})$",
+          "title": "Digest",
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "openpgp-ascii-armored",
+            "openpgp-binary"
+          ],
+          "title": "Format",
+          "type": "string"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "not": {
+                "anyOf": [
+                  {
+                    "pattern": "^https://[^/?#]*@"
+                  },
+                  {
+                    "pattern": "[?&](?:access_token|api_key|apikey|auth|credential|key|password|secret|sig|signature|token)(?:=|&|$)"
+                  }
+                ]
+              },
+              "pattern": "^https://[^\\s#]+$",
+              "type": "string"
+            },
+            {
+              "pattern": "^\\$\\{((?:(?:[a-z0-9][a-z0-9_-]{0,63}|__private)\\.)*[a-z0-9][a-z0-9_-]{0,63})\\}$",
+              "type": "string",
+              "x-raes-variable-reference": true
+            }
+          ],
+          "description": "Credential-free HTTPS location of the public signing-key bytes.",
+          "title": "Uri"
+        }
+      },
+      "required": [
+        "uri",
+        "format",
+        "digest"
+      ],
+      "title": "RuntimePackageRepositorySigningKey",
       "type": "object"
     },
     "RuntimePlatformApplication": {

--- a/docs/decisions/issue-847-runtime-package-repositories-preflight.md
+++ b/docs/decisions/issue-847-runtime-package-repositories-preflight.md
@@ -1,0 +1,294 @@
+# Issue 847 Runtime Package Repository Preflight
+
+Date: 2026-09-04
+
+Issue: #847. Requirement: none; the issue is the authoritative delivery
+contract.
+
+Status: architecture guidance only. This note does not change SDL syntax,
+models, schemas, compiler behavior, backend support, or package installation.
+Existing decisions already own the relevant boundaries, so no new ADR or ADR
+amendment is required.
+
+## Architectural Diagnosis
+
+`RuntimePackage` is currently a closed object only in the Pydantic/JSON Schema
+sense. Its `manager`, `name`, `version`, `source`, and `purl` members are plain
+strings, and neither `source` nor `purl` defines an executable package-source
+contract. They must not acquire private APTL semantics:
+
+- `purl` is package identity metadata. It is not a repository locator, signing
+  key, acquisition route, or trust assertion.
+- `source` remains an opaque, non-executable source/provenance label for
+  compatibility. A backend must never parse it as a repository line, options
+  map, URL bundle, shell fragment, or command.
+- `RuntimeSoftwareComponent`, `Source.build`, `ArtifactRequirement`, module
+  registry trust, associated artifacts, and experiment evidence have adjacent
+  identity/provenance roles, but none is the effective package-manager
+  repository configuration of a node. Reusing one would conflate artifact
+  identity, build provenance, reusable-asset acquisition, or evidence with
+  package installation state.
+
+At the same time, issue #1078 already makes `runtime.packages` the exact,
+guest-observed `runtime-packages` SEM-218 concern. The compiler, plan authority,
+support admission, returned-snapshot validation, and persistence path all
+consume that one concern. A second `package-repositories` runtime collection,
+compiler resource, realization kind, or backend-local side table would split
+one package requirement across duplicate authorities without being necessary
+for the Wazuh/Grafana shape.
+
+## Contract Boundary
+
+Add one optional, closed `repository` child to `RuntimePackage`. Absence keeps
+the current meaning: the package is obtainable through the selected target's
+ordinary configured package sources. Presence requires the backend to realize
+the declared source and trust binding before installing the exact package. The
+repository and dedicated trust binding are required final node state, not a
+transient bootstrap hint; a future remove-after-install lifecycle would need
+separately typed semantics rather than an undocumented cleanup step.
+
+The child is a discriminated, versioned profile union. The initial profile is
+APT only and has this semantic shape (field spelling is fixed here so
+downstream implementations do not invent alternatives):
+
+```yaml
+runtime:
+  packages:
+    - manager: apt
+      name: wazuh-agent
+      version: 4.12.0-1
+      repository:
+        repository_profile: apt
+        profile_version: "1"
+        uri: https://packages.wazuh.com/4.x/apt/
+        suite: stable
+        components: [main]
+        signing_key:
+          uri: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+          format: openpgp-ascii-armored
+          digest: sha256:<64-lowercase-hex-digits>
+```
+
+The profile means a binary APT repository with the exact base URI, suite, and
+component set, trusted only by the exact public signing-key bytes named by the
+SHA-256 digest. `format` is initially the closed set
+`openpgp-ascii-armored` / `openpgp-binary`; a backend must not sniff content to
+decide whether to dearmor it. `components` is non-empty, duplicate-free, and
+set-like for semantic comparison. `suite` and component members are bounded
+APT tokens, not whitespace-bearing source fragments.
+
+The package `manager` and profile discriminator must agree (`apt` with `apt`).
+The profile does not silently normalize `apt-get`, `debian`, `dpkg`, or another
+manager spelling to `apt`. Existing packages without `repository` retain their
+current compatibility; governing every historical manager/name/version string
+is outside this issue. When this profile is present, however, APT package name,
+version, URI, suite, component, key format, and digest values must pass the
+profile's closed validation before compilation.
+
+Do not expose an authored `signed_by`, source-list filename, keyring filename,
+raw `deb ...` line, arbitrary options dictionary, install command, environment
+map, or script. Those are OS rendering details. A supporting backend derives
+collision-resistant owned filenames from the canonical repository/package
+identity and always scopes that repository to its dedicated keyring. This
+prevents SDL from choosing arbitrary root-owned paths or adding global trust.
+
+The key digest is mandatory. HTTPS without a pinned trust-root payload is not
+sufficient for exact repeatable realization, and a key URL or claimed key id is
+not integrity. The digest binds bytes; it does not by itself prove that the
+author selected the correct vendor key. Signing-key material is public
+verification material, never a private key or credential.
+
+Scalar leaves may use the repository's existing whole-field variable mechanism
+only where the authoring schema represents the literal-or-variable union. A
+bound value must pass the same concrete validator during normal instantiation.
+The profile/version discriminator and collection structure are never variable.
+No unresolved repository value may reach backend admission.
+
+## Ownership, Realization, And Extensibility
+
+The repository child remains inside the existing `runtime-packages` semantic
+identity and projection. It does not add a 33rd `RuntimeConfiguration` field or
+a second realization concern. The package collection's stable identity remains
+the normalized `(manager, name, architecture)` tuple identified by the #1078
+boundary audit; duplicate identities, conflicting versions, and conflicting
+repository definitions for that identity fail closed rather than relying on
+list order or last-write-wins behavior.
+
+The existing typed runtime projector should include the closed repository
+profile, normalize set-like `components`, and retain package/repository/key
+identity. It must not retain downloaded key bytes, rendered files, native
+package-manager output, cache state, commands, or backend paths. Exact
+realization means the backend independently verifies the installed package
+tuple, effective APT source tuple, dedicated key binding, and fetched key
+digest before returning the matching safe projection. Echoing the submitted
+payload or reporting only a successful `apt-get` exit status is not readback.
+
+The extensibility seam is `repository_profile` plus `profile_version` on a
+discriminated union. A future RPM/DNF/YUM, APK, Zypper, or authenticated private
+repository gets its own closed profile with its own native semantics and
+capability/readback evidence. It does not add optional RPM fields to the APT
+profile, an `options: {}` escape hatch, or backend-product conditionals to the
+SDL/compiler. Additive APT semantics require an explicit profile-version
+decision rather than changing what profile `apt`/`1` means silently.
+
+## Canonical Incumbents To Reuse
+
+- **SDL shape and module boundary:** `raes._base.SDLModel(extra="forbid")`,
+  `raes.runtime_values`, `raes.runtime_configuration`, and the facade exports
+  in `raes.nodes`. Keep cohesive package repository models in a dedicated
+  `raes.runtime_packages` module so `runtime_configuration.py` remains below
+  ADR-015's 500-line cap; do not create a new top-level Python package.
+- **URI and digest safety:** reuse
+  `raes_contracts.uri_safety.validate_safe_absolute_uri` for absolute,
+  credential-free URI parsing and the repository's canonical SHA-256 digest
+  grammar. Add only the profile-specific HTTPS and fragment restrictions; do
+  not add another URL parser, checksum object family, or cryptographic helper.
+- **Parsing and validation:** `raes._yaml_loader.load_sdl_yaml`,
+  `SDLParserLimits`, `raes.parser`, `SemanticValidator`, `SDLParseError`,
+  `SDLValidationError`, `instantiate_scenario()`, and
+  `SDLInstantiationError` remain the only language ingress and error
+  hierarchy. Local profile invariants belong on the closed model; only
+  cross-node/package relations belong in the existing node semantic pass.
+- **Author intent:** preserve `model_fields_set`, `raes.explicitness`,
+  `raes.realization_designation`, instantiation provenance, and concrete
+  revalidation. Do not infer declaration or defaults from `model_dump()`.
+- **Compilation and admission:** reuse `_compile_node_runtimes()`, the existing
+  node `spec.node.runtime.packages` payload, `RuntimeConcernProfile("packages",
+  "runtime-packages")`, `RealizationConcernDescriptor`,
+  `CompiledRealizationRequirement`, plan-owned realization authority,
+  `realization_support_diagnostics()`, and realization-envelope admission. No
+  repository DTO, resource, plan, concern kind, support boolean, or manifest is
+  justified.
+- **Execution and evidence:** reuse `Provisioner.validate`,
+  `raes_runtime.backend_calls._call_backend_apply`,
+  `realization_authority_disclosure()`, `Diagnostic`, `ApplyResult`,
+  `RealizationObservationDisclosure`, and the existing
+  `runtime.backend-contract-invalid` failure. A backend may add support only
+  when its selected configuration advertises complete `runtime-packages`
+  exact support and matching configuration-scope, guest-observed capability.
+- **Persistence and API:** reuse `RuntimeSnapshot`, `SnapshotEntry`,
+  `RealizationProvenanceEntry`, `RuntimeSnapshotEnvelopeModel`,
+  `ControlPlaneStore`, its existing serializers, and authorized snapshot
+  routes. Do not add a repository cache, database table, sidecar, metadata
+  escape hatch, or log-only evidence path.
+- **Normative contract workflow:** ADR-009/061, the four Node-bearing schemas
+  (`sdl-authoring-input-v1`, `instantiated-scenario-v1`,
+  `instantiated-scenario-snapshot-v1`, and
+  `scenario-satisfiability-evidence-v1`), `schema_bundle()`, positive and
+  negative SDL fixtures, `contracts/schema-publication-manifest.json`,
+  `tools/check_generated_schemas.py`, and
+  `tools/check_schema_publication.py` move together. `docs/explain/sdl/sections.md`
+  must describe the public field semantics; Python docstrings alone are not the
+  portable contract.
+- **Repository workflow:** `.ground-control.yaml`, `.gc/plan-rules.md`,
+  ADR-015 module/size checks, repo policy, requirement-free issue handling, and
+  `tools/verify_all.py` remain the verification authority. `CHANGELOG.md` and
+  package versions remain release-please owned.
+
+## Cross-Cutting Security And Runtime Gates
+
+1. **Source/parser shape.** Bounded UTF-8 safe-YAML loading, alias/depth/node
+   limits, duplicate/merge-key rejection, canonical key handling, and closed
+   model validation run before any URI or package can become executable. URI
+   validation is inert and performs no DNS or network access.
+2. **SDL/config shape.** Repository and key URIs are HTTPS, absolute, bounded,
+   and free of userinfo, secret-bearing query fields, and fragments. The key
+   digest is canonical lowercase SHA-256. Suite/components/package tokens
+   exclude whitespace, control characters, leading option syntax, and source
+   line delimiters. Profile fields are closed; arbitrary APT options fail.
+3. **Semantic/instantiation shape.** Repository/profile/manager agreement,
+   unique package identities, architecture compatibility, variable provenance,
+   and concrete post-binding validation finish before compilation. The compiler
+   does not parse YAML, URLs, APT lines, or reimplement these checks.
+4. **Plan/manifest/config admission.** The enriched value flows through the
+   existing `runtime-packages` payload and concern. Exact support is valid only
+   for a backend configuration that supports the APT profile, key verification,
+   package pin, and independent readback as one complete operation. The generic
+   concern-kind token alone is not a value-level package-manager claim; the
+   selected configuration's existing realization envelope must bound the
+   manager/repository profile it actually supports. Existing stub/reference/
+   libvirt manifests must not be widened just to accept fixtures.
+5. **Network/SSRF boundary.** The SDL URI is data, not permission for arbitrary
+   egress. A supporting backend must apply its canonical egress policy before
+   fetching, reject disallowed hosts/addresses and DNS rebinding, revalidate
+   every redirect, bound redirects/bytes/time, stream to protected temporary
+   storage, and verify the digest before parsing or installing the key. If that
+   backend has no such policy/channel, it reports the profile unsupported.
+6. **Trust and filesystem boundary.** Never use `apt-key` or a global trusted
+   keyring. Render a dedicated source file and `signed-by` keyring at
+   deterministic backend-owned paths; reject unowned collisions and symlinks,
+   use restrictive creation/atomic replacement, and clean up only owned files
+   on failure. Reconciliation must be idempotent and serialize through the
+   target package manager's existing lock rather than racing concurrent
+   updates.
+7. **Process/argv boundary.** Render structured source data, never shell text.
+   Package-manager and GPG invocations use fixed executables, argument arrays,
+   no shell, `--`/manager-specific end-of-options handling, bounded stdin/files,
+   controlled environment and working directory, and timeouts. Repository
+   URLs, keys, packages, or versions never become executable fragments. No
+   credential is permitted in SDL, environment, argv, or generated filenames.
+8. **Secret/auth surface.** Public key bytes and digests are non-secret. Private
+   repository credentials, bearer tokens, client keys, proxy credentials, and
+   private signing keys are unrepresentable in this profile. Repository URIs
+   become scenario/snapshot data visible through existing authorized reads, so
+   authors must not use credential-bearing or secret locators. A future private
+   repository needs the existing secret-reference/binding discipline and a
+   separately governed profile; it must not add a password field here.
+9. **Backend return and error envelope.** `_call_backend_apply()` remains the
+   sole acceptance boundary. Invalid/missing observation, digest mismatch,
+   package mismatch, malformed result, or native failure returns the baseline
+   snapshot with a coarse addressed diagnostic. Diagnostics, audit, API 422/500
+   envelopes, and logs may name package/repository profile and stable reason
+   code, but never key bytes, response bodies, full URIs with query data,
+   rendered files, argv, native stderr, exception text, or tracebacks.
+10. **Persistence/observability.** Only the validated safe package/repository
+    projection, value-free provenance, and typed observation disclosure enter
+    snapshots/stores. Download buffers, key material, package-manager caches,
+    output, and temporary files remain backend-private. Existing strict control
+    plane authentication, roles, target binding, request-size/idempotency
+    guards, and audit apply; authentication does not make unsafe payloads safe.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- encoding `repo=...;key=...`, JSON, YAML, a `deb` line, or a command in
+  `source`, `purl`, or another string;
+- treating purl, HTTPS, a key URL, a short key id, TLS success, package install
+  success, or plan echo as repository/key integrity or realization evidence;
+- accepting an unpinned key, trusting a global keyring, calling `apt-key`, or
+  allowing an authored root path;
+- using a generic `url/key/options` bag across APT and RPM-family managers;
+- duplicating one repository under a new top-level runtime family, concern,
+  compiler resource, DTO, manifest flag, exception tree, store, or logger;
+- selecting the repository from package name, OS hints, backend defaults,
+  ambient environment, or the controller host;
+- silently accepting conflicting duplicate package/repository rows or relying
+  on list order;
+- passing a rendered source line to a shell, interpolating fields into argv
+  fragments/filenames, or logging subprocess output and downloaded key bytes;
+- adding credentials to the URI, SDL, plan, snapshot, environment, command
+  line, audit event, fixture, or diagnostic; or
+- claiming `runtime-packages` support when only default-repository packages are
+  implemented or when repository/key readback is absent.
+
+## Non-Goals And Implementation Boundaries
+
+- This preflight does not implement models, schemas, validators, backend
+  materialization, APTL changes, or conformance tests.
+- The issue does not standardize all package managers, package-name/version
+  grammars, dependency resolution, repository mirrors, pin priorities,
+  authenticated/private repositories, proxies, source packages, key rotation,
+  revocation, transparency, or offline bundles.
+- It does not reinterpret or remove the existing `source`/`purl` fields, import
+  raw SBOM/package-manager output, or turn package repositories into reusable
+  `Source`, build provenance, experiment evidence, or artifact-requirement
+  graphs.
+- It does not require in-repository reference or libvirt support. Those
+  backends remain honest/unsupported until they implement the whole declared
+  profile and independent observation contract. Downstream APTL owns its
+  privileged runner, egress controls, rollback, and actual cutover.
+- Backend-specific repository filenames, keyring paths, cache layout, command
+  choice, privilege mechanism, transaction/rollback implementation, and host
+  configuration remain backend-private. Their effects must satisfy the
+  portable profile; their native representation does not enter SDL.

--- a/docs/explain/sdl/sections.md
+++ b/docs/explain/sdl/sections.md
@@ -831,7 +831,43 @@ posture — `default`, `unconfined`, a named profile, or a profile path) and
 such as `seccomp:unconfined` or `no-new-privileges`); a seccomp posture is a
 distinct security control from `privileged`, so it is recorded separately (see
 [ADR-028](../../decisions/adrs/adr-028-container-seccomp-security-options-surface.md));
-`packages` records package-manager rows; `software_components` records
+`packages` records package-manager rows. A package without `repository` is
+obtained from the target's ordinary configured sources. The optional
+`repository` child declares required final repository state through a closed,
+versioned profile. Profile `apt` version `1` is the initial portable form:
+
+```yaml
+packages:
+  - manager: apt
+    name: wazuh-agent
+    version: 4.12.0-1
+    repository:
+      repository_profile: apt
+      profile_version: "1"
+      uri: https://packages.wazuh.com/4.x/apt/
+      suite: stable
+      components: [main]
+      signing_key:
+        uri: https://packages.wazuh.com/key/GPG-KEY-WAZUH
+        format: openpgp-ascii-armored
+        digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+```
+
+Repository and signing-key URIs are credential-free HTTPS locations. The key
+digest pins the exact public OpenPGP bytes, and `format` states whether those
+bytes are `openpgp-ascii-armored` or `openpgp-binary`; a backend must not infer
+the format from content. `suite` and the non-empty, duplicate-free
+`components` collection are structured APT values, not fragments of a `deb`
+line. The package manager must be exactly `apt`, matching the profile. Backend
+implementations own dedicated keyring/source-list paths and safe fetching,
+digest verification, rendering, locking, installation, and independent
+readback. The SDL cannot supply a `signed-by` path, an options map, a command,
+credentials, or private key material. `source` remains an opaque provenance
+label and `purl` remains package identity metadata; neither is parsed as a
+repository or executable value. Future package managers use their own closed
+profile and version rather than adding manager-specific options to this one.
+
+`software_components` records
 node-local software identity at component granularity with stable RAES ids,
 component type, version, purl/CPE/hash identifiers, package or manifest
 lineage, and runtime paths when required; and `dependency_manifests` records

--- a/docs/requirements/SEM-218/requirement.md
+++ b/docs/requirements/SEM-218/requirement.md
@@ -6,7 +6,7 @@ type: FUNCTIONAL
 priority: MUST
 wave: 2
 created_at: 2026-04-05T00:54:58.405111Z
-updated_at: 2026-09-03T00:00:00Z
+updated_at: 2026-09-04T00:00:00Z
 ---
 
 # SEM-218 — Explicitness And Realization Semantics
@@ -102,3 +102,6 @@ Current state: identified gap. Honest portability requires normative semantics f
 - DOCUMENTS → DOCUMENTATION `docs/decisions/issue-1078-runtime-configuration-boundary-remediation.md` (Issue 1078 implementation and backend-boundary decision)
 - IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_processor/semantics/realization_runtime_concern_profiles.py` (Executable RuntimeConfiguration ownership and enforcement inventory)
 - TESTS → TEST `implementations/python/tests/test_issue_1078_runtime_boundary_coverage.py` (Complete runtime concern, posture, closure, observation, and secret conformance)
+- DOCUMENTS → DOCUMENTATION `docs/decisions/issue-847-runtime-package-repositories-preflight.md` (Typed package-repository profile and existing runtime-packages authority boundary)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes/runtime_packages.py` (Closed, pinned APT repository profile within the runtime-packages concern)
+- TESTS → TEST `implementations/python/tests/test_issue_847_runtime_package_repositories.py` (Repository validation, compilation, projection, schema, and compatibility coverage)

--- a/implementations/python/packages/raes/nodes.py
+++ b/implementations/python/packages/raes/nodes.py
@@ -49,6 +49,7 @@ from .operating_systems import (
     normalize_os_version,
 )
 from .runtime_configuration import (
+    RuntimeAptPackageRepository,
     RuntimeCapabilityOverrideScope,
     RuntimeCapabilityPolicy,
     RuntimeConfiguration,
@@ -81,6 +82,8 @@ from .runtime_configuration import (
     RuntimeNetworkRealization,
     RuntimeOperationalPolicy,
     RuntimePackage,
+    RuntimePackageRepository,
+    RuntimePackageRepositorySigningKey,
     RuntimeProcessCapabilityOverride,
     RuntimeProcessIdentity,
     RuntimeProcessLimitResource,
@@ -158,7 +161,10 @@ __all__ = [
     "RuntimeNetworkEndpoint",
     "RuntimeNetworkRealization",
     "RuntimeOperationalPolicy",
+    "RuntimeAptPackageRepository",
     "RuntimePackage",
+    "RuntimePackageRepository",
+    "RuntimePackageRepositorySigningKey",
     "RuntimeProcessCapabilityOverride",
     "RuntimeProcessIdentity",
     "RuntimeProcessLimitResource",

--- a/implementations/python/packages/raes/runtime_configuration.py
+++ b/implementations/python/packages/raes/runtime_configuration.py
@@ -28,7 +28,6 @@ from ._base import (
     parse_int_or_var,
 )
 from ._runtime_service_families import install_runtime_service_family_exports
-from .architectures import PackageArchitectureString, normalize_architecture
 from .runtime_capabilities import (
     RuntimeCapabilityOverrideScope,
     RuntimeCapabilityPolicy,
@@ -80,6 +79,12 @@ from .runtime_network import (
     RuntimeNetworkEndpoint,
     RuntimeNetworkRealization,
     RuntimePublishedPort,
+)
+from .runtime_packages import (
+    RuntimeAptPackageRepository,
+    RuntimePackage,
+    RuntimePackageRepository,
+    RuntimePackageRepositorySigningKey,
 )
 from .runtime_resource_limits import (
     RuntimeProcessLimitResource,
@@ -145,7 +150,10 @@ __all__ = [
     "RuntimeNetworkEndpoint",
     "RuntimeNetworkRealization",
     "RuntimeOperationalPolicy",
+    "RuntimeAptPackageRepository",
     "RuntimePackage",
+    "RuntimePackageRepository",
+    "RuntimePackageRepositorySigningKey",
     "RuntimeProcessCapabilityOverride",
     "RuntimeProcessIdentity",
     "RuntimeProcessLimitResource",
@@ -232,31 +240,6 @@ class RuntimeOperationalPolicy(SDLModel):
         return _parse_runtime_enum_or_var(v, RuntimeRestartPolicy, field_name="restart")
 
 
-class RuntimePackage(SDLModel):
-    """A package required in a runtime image or node."""
-
-    manager: str
-    name: str
-    version: str
-    architecture: PackageArchitectureString = ""
-    source: str = ""
-    purl: str = ""
-
-    @field_validator("architecture", mode="before")
-    @classmethod
-    def normalize_package_architecture(cls, v: object) -> object:
-        """Normalize a populated package architecture to a canonical token.
-
-        Empty stays empty (the package is not architecture-constrained); a
-        populated value uses the same governed vocabulary as ``Node.architecture``
-        so target/package comparison is exact.
-        """
-        if v is None or v == "":
-            return v
-        normalized = normalize_architecture(v)
-        return normalized.value if hasattr(normalized, "value") else normalized
-
-
 class RuntimeDependencyManifest(SDLModel):
     """A dependency manifest required in the runtime artifact."""
 
@@ -282,6 +265,18 @@ def _reject_duplicate_keys(items: Iterable[object], *, attr: str, label: str) ->
         if key in seen:
             raise ValueError(f"Duplicate runtime {label} '{key}'")
         seen.add(key)
+
+
+def _reject_duplicate_package_identities(packages: Iterable[RuntimePackage]) -> None:
+    """Reject ambiguous package rows by their stable semantic identity."""
+
+    seen: set[tuple[str, str, str]] = set()
+    for package in packages:
+        identity = (package.manager, package.name, package.architecture)
+        if identity in seen:
+            rendered = ":".join(identity)
+            raise ValueError(f"Duplicate runtime package identity '{rendered}'")
+        seen.add(identity)
 
 
 class RuntimeConfiguration(SDLModel):
@@ -394,5 +389,6 @@ class RuntimeConfiguration(SDLModel):
         _reject_duplicate_keys(self.identity_authorities, attr="identity_authority_id", label="identity authority")
         _reject_duplicate_keys(self.file_services, attr="file_service_id", label="file_service file_service_id")
         _reject_duplicate_keys(self.mail_services, attr="mail_service_id", label="mail_service mail_service_id")
+        _reject_duplicate_package_identities(self.packages)
         _reject_duplicate_keys(self.software_components, attr="component_id", label="software component")
         return self

--- a/implementations/python/packages/raes/runtime_packages.py
+++ b/implementations/python/packages/raes/runtime_packages.py
@@ -1,0 +1,233 @@
+"""Typed runtime package and third-party repository declarations."""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated, Literal
+from urllib.parse import urlsplit
+
+from pydantic import Field, GetJsonSchemaHandler, WithJsonSchema, field_validator, model_validator
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
+from raes_contracts.uri_safety import validate_safe_absolute_uri
+
+from ._base import VARIABLE_REFERENCE_SCHEMA_MARKER, VARIABLE_TOKEN_PATTERN, SDLModel, is_variable_ref
+from .architectures import PackageArchitectureString, normalize_architecture
+
+_HTTPS_URI_OR_VARIABLE_PATTERN = rf"^(?:https://[^\s#]+|{VARIABLE_TOKEN_PATTERN})$"
+_SHA256_OR_VARIABLE_PATTERN = rf"^(?:sha256:[a-f0-9]{{64}}|{VARIABLE_TOKEN_PATTERN})$"
+_APT_SUITE_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9.+_~:-]{0,127}$"
+_APT_COMPONENT_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9.+_~-]{0,127}$"
+_APT_PACKAGE_NAME_PATTERN = r"^[a-z0-9][a-z0-9+.-]{0,127}$"
+_APT_PACKAGE_VERSION_PATTERN = r"^[0-9][A-Za-z0-9.+:~_-]{0,255}$"
+
+HttpsUriOrVariable = Annotated[
+    str,
+    Field(min_length=1, max_length=2048, pattern=_HTTPS_URI_OR_VARIABLE_PATTERN),
+    WithJsonSchema(
+        {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2048,
+                    "pattern": r"^https://[^\s#]+$",
+                    "not": {
+                        "anyOf": [
+                            {"pattern": r"^https://[^/?#]*@"},
+                            {
+                                "pattern": (
+                                    r"[?&](?:access_token|api_key|apikey|auth|credential|key|password|"
+                                    r"secret|sig|signature|token)(?:=|&|$)"
+                                )
+                            },
+                        ]
+                    },
+                },
+                {
+                    "type": "string",
+                    "pattern": rf"^{VARIABLE_TOKEN_PATTERN}$",
+                    VARIABLE_REFERENCE_SCHEMA_MARKER: True,
+                },
+            ]
+        }
+    ),
+]
+Sha256DigestOrVariable = Annotated[
+    str,
+    Field(pattern=_SHA256_OR_VARIABLE_PATTERN),
+]
+AptSuiteToken = Annotated[str, Field(min_length=1, max_length=128, pattern=_APT_SUITE_PATTERN)]
+AptComponentToken = Annotated[str, Field(min_length=1, max_length=128, pattern=_APT_COMPONENT_PATTERN)]
+
+
+def _validate_https_uri(value: object, *, field_name: str) -> object:
+    """Validate an inert public HTTPS URI without dereferencing it."""
+
+    if is_variable_ref(value):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    validate_safe_absolute_uri(value, field_name=field_name, forbid_fragment=True)
+    if urlsplit(value).scheme.casefold() != "https":
+        raise ValueError(f"{field_name} must use HTTPS")
+    return value
+
+
+def _is_safe_apt_token(value: object, pattern: str) -> bool:
+    return is_variable_ref(value) or isinstance(value, str) and re.fullmatch(pattern, value, re.ASCII) is not None
+
+
+class RuntimePackageRepositorySigningKey(SDLModel):
+    """Exact public OpenPGP key bytes trusted by one package repository."""
+
+    uri: HttpsUriOrVariable = Field(
+        description="Credential-free HTTPS location of the public signing-key bytes.",
+    )
+    format: Literal["openpgp-ascii-armored", "openpgp-binary"]
+    digest: Sha256DigestOrVariable = Field(
+        description="Canonical SHA-256 digest of the exact public signing-key bytes.",
+    )
+
+    @field_validator("uri", mode="before")
+    @classmethod
+    def validate_uri(cls, value: object) -> object:
+        return _validate_https_uri(value, field_name="signing key uri")
+
+
+class RuntimeAptPackageRepository(SDLModel):
+    """Version 1 portable binary APT repository and dedicated trust binding."""
+
+    repository_profile: Literal["apt"]
+    profile_version: Literal["1"]
+    uri: HttpsUriOrVariable = Field(
+        description="Credential-free HTTPS base URI of the binary APT repository.",
+    )
+    suite: AptSuiteToken
+    components: list[AptComponentToken] = Field(
+        min_length=1,
+        max_length=32,
+        json_schema_extra={"uniqueItems": True},
+    )
+    signing_key: RuntimePackageRepositorySigningKey
+
+    @field_validator("uri", mode="before")
+    @classmethod
+    def validate_uri(cls, value: object) -> object:
+        return _validate_https_uri(value, field_name="repository uri")
+
+    @field_validator("suite", mode="before")
+    @classmethod
+    def validate_suite(cls, value: object) -> object:
+        if not _is_safe_apt_token(value, _APT_SUITE_PATTERN):
+            raise ValueError("suite must be a bounded APT token")
+        return value
+
+    @field_validator("components", mode="before")
+    @classmethod
+    def validate_components(cls, value: object) -> object:
+        if not isinstance(value, list) or not value:
+            raise ValueError("components must contain at least one APT component")
+        if any(not _is_safe_apt_token(component, _APT_COMPONENT_PATTERN) for component in value):
+            raise ValueError("component must be a bounded APT token")
+        if len(value) != len(set(value)):
+            raise ValueError("components must not contain duplicates")
+        return sorted(value)
+
+
+# The profile discriminator and version are fixed on the initial member. Future
+# managers extend this public alias with their own closed profile models.
+RuntimePackageRepository = Annotated[
+    RuntimeAptPackageRepository,
+    Field(discriminator="repository_profile"),
+]
+
+
+class RuntimePackage(SDLModel):
+    """An exact package required in a runtime image or node.
+
+    ``repository`` is absent for ordinary target-configured repositories. When
+    present, it is required final node state and stays within the existing
+    ``runtime-packages`` realization concern.
+    """
+
+    manager: str = Field(description="Package manager identity used by the target node.")
+    name: str = Field(description="Package name interpreted by the selected package manager.")
+    version: str = Field(description="Exact package version interpreted by the selected package manager.")
+    architecture: PackageArchitectureString = ""
+    source: str = Field(
+        default="",
+        description="Opaque package source or provenance label; never a repository declaration or executable value.",
+    )
+    purl: str = Field(
+        default="",
+        description="Package URL identity metadata; never a repository locator, trust binding, or acquisition command.",
+    )
+    repository: RuntimePackageRepository | None = Field(
+        default=None,
+        description="Closed third-party repository profile; absence selects the target's ordinary configured sources.",
+    )
+
+    @field_validator("architecture", mode="before")
+    @classmethod
+    def normalize_package_architecture(cls, value: object) -> object:
+        """Normalize a populated package architecture to a canonical token."""
+
+        if value is None or value == "":
+            return value
+        normalized = normalize_architecture(value)
+        return normalized.value if hasattr(normalized, "value") else normalized
+
+    @model_validator(mode="after")
+    def validate_repository_package(self) -> RuntimePackage:
+        if self.repository is None:
+            return self
+        if self.manager != self.repository.repository_profile:
+            raise ValueError("repository profile 'apt' requires package manager 'apt'")
+        if not _is_safe_apt_token(self.name, _APT_PACKAGE_NAME_PATTERN):
+            raise ValueError("package name must be a bounded APT token")
+        if not _is_safe_apt_token(self.version, _APT_PACKAGE_VERSION_PATTERN):
+            raise ValueError("package version must be a bounded APT token")
+        return self
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        schema = handler.resolve_ref_schema(handler(core_schema))
+        schema.setdefault("allOf", []).append(
+            {
+                "if": {
+                    "required": ["repository"],
+                    "properties": {"repository": {"not": {"type": "null"}}},
+                },
+                "then": {
+                    "properties": {
+                        "manager": {"const": "apt"},
+                        "name": {
+                            "anyOf": [
+                                {"pattern": _APT_PACKAGE_NAME_PATTERN},
+                                {"pattern": rf"^{VARIABLE_TOKEN_PATTERN}$"},
+                            ]
+                        },
+                        "version": {
+                            "anyOf": [
+                                {"pattern": _APT_PACKAGE_VERSION_PATTERN},
+                                {"pattern": rf"^{VARIABLE_TOKEN_PATTERN}$"},
+                            ]
+                        },
+                    }
+                },
+            }
+        )
+        return schema
+
+
+__all__ = [
+    "RuntimeAptPackageRepository",
+    "RuntimePackage",
+    "RuntimePackageRepository",
+    "RuntimePackageRepositorySigningKey",
+]

--- a/implementations/python/tests/test_issue_847_runtime_package_repositories.py
+++ b/implementations/python/tests/test_issue_847_runtime_package_repositories.py
@@ -135,8 +135,10 @@ def test_repository_components_are_canonical_set_like_values() -> None:
     ),
 )
 def test_repository_profile_rejects_unsafe_or_ambiguous_input(repository: dict[str, object], message: str) -> None:
+    package = _package(repository=repository)
+
     with pytest.raises(ValidationError, match=message):
-        RuntimePackage.model_validate(_package(repository=repository))
+        RuntimePackage.model_validate(package)
 
 
 @pytest.mark.parametrize(
@@ -169,15 +171,15 @@ def test_default_repository_packages_keep_backward_compatible_opaque_metadata() 
 
 
 def test_runtime_configuration_rejects_duplicate_package_identity() -> None:
+    runtime = {
+        "packages": [
+            _package(version="4.12.0-1"),
+            _package(version="4.13.0-1", repository=_repository(uri="https://packages.example.test/apt")),
+        ]
+    }
+
     with pytest.raises(ValidationError, match="Duplicate runtime package identity 'apt:wazuh-agent:'"):
-        RuntimeConfiguration.model_validate(
-            {
-                "packages": [
-                    _package(version="4.12.0-1"),
-                    _package(version="4.13.0-1", repository=_repository(uri="https://packages.example.test/apt")),
-                ]
-            }
-        )
+        RuntimeConfiguration.model_validate(runtime)
 
 
 def test_runtime_configuration_allows_same_package_name_for_distinct_identity_dimensions() -> None:

--- a/implementations/python/tests/test_issue_847_runtime_package_repositories.py
+++ b/implementations/python/tests/test_issue_847_runtime_package_repositories.py
@@ -1,0 +1,273 @@
+"""Issue #847: typed, pinned third-party runtime package repositories."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+from raes import SDLInstantiationError, SDLParseError, instantiate_scenario, parse_sdl
+from raes.nodes import RuntimeAptPackageRepository as NodeRuntimeAptPackageRepository
+from raes.runtime_configuration import RuntimeAptPackageRepository, RuntimeConfiguration, RuntimePackage
+from raes_contracts.contracts import schema_bundle
+from raes_processor.compiler import compile_runtime_model
+from raes_processor.semantics.realization_concerns import project_realization_concern
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = REPO_ROOT / "contracts" / "fixtures" / "sdl" / "runtime-package-repository-v1"
+SCHEMA_PATHS = (
+    REPO_ROOT / "contracts" / "schemas" / "sdl" / "sdl-authoring-input-v1.json",
+    REPO_ROOT / "contracts" / "schemas" / "sdl" / "instantiated-scenario-v1.json",
+    REPO_ROOT / "contracts" / "schemas" / "sdl" / "instantiated-scenario-snapshot-v1.json",
+    REPO_ROOT / "contracts" / "schemas" / "satisfiability" / "scenario-satisfiability-evidence-v1.json",
+)
+KEY_DIGEST = "sha256:" + "a" * 64
+
+
+def _repository(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "repository_profile": "apt",
+        "profile_version": "1",
+        "uri": "https://packages.wazuh.com/4.x/apt/",
+        "suite": "stable",
+        "components": ["main"],
+        "signing_key": {
+            "uri": "https://packages.wazuh.com/key/GPG-KEY-WAZUH",
+            "format": "openpgp-ascii-armored",
+            "digest": KEY_DIGEST,
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def _package(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "manager": "apt",
+        "name": "wazuh-agent",
+        "version": "4.12.0-1",
+        "repository": _repository(),
+    }
+    value.update(overrides)
+    return value
+
+
+def test_repository_profile_round_trips_through_parser_compiler_and_projection() -> None:
+    source = (FIXTURE_ROOT / "valid" / "wazuh.yaml").read_text(encoding="utf-8")
+
+    scenario = parse_sdl(source)
+    package = scenario.nodes["manager"].runtime.packages[0]
+    compiled = compile_runtime_model(scenario)
+    compiled_package = compiled.node_deployments["provision.node.manager"].spec["node"]["runtime"]["packages"][0]
+    projected = project_realization_concern("runtime-packages", [compiled_package])
+
+    assert package.repository.repository_profile == "apt"
+    assert package.repository.profile_version == "1"
+    assert package.repository.signing_key.digest == KEY_DIGEST
+    assert compiled_package["repository"] == package.repository.model_dump(mode="json")
+    assert projected[0]["repository"]["components"] == ["main"]
+    assert NodeRuntimeAptPackageRepository is RuntimeAptPackageRepository
+
+
+def test_repository_components_are_canonical_set_like_values() -> None:
+    package = RuntimePackage.model_validate(
+        _package(repository=_repository(components=["non-free", "main", "contrib"]))
+    )
+
+    assert package.repository.components == ["contrib", "main", "non-free"]
+    projected = project_realization_concern("runtime-packages", [package.model_dump(mode="json")])
+    assert projected[0]["repository"]["components"] == ["contrib", "main", "non-free"]
+
+
+@pytest.mark.parametrize(
+    ("repository", "message"),
+    (
+        (_repository(uri="http://packages.example.test/apt"), "repository uri must use HTTPS"),
+        (_repository(uri="https://user:password@example.test/apt"), "credential userinfo"),
+        (_repository(uri="https://example.test/apt#stable"), "must not contain a fragment"),
+        (
+            _repository(
+                signing_key={
+                    "uri": "https://example.test/key?access_token=secret",
+                    "format": "openpgp-binary",
+                    "digest": KEY_DIGEST,
+                }
+            ),
+            "secret-bearing query fields",
+        ),
+        (
+            _repository(
+                signing_key={
+                    "uri": "http://example.test/key",
+                    "format": "openpgp-binary",
+                    "digest": KEY_DIGEST,
+                }
+            ),
+            "signing key uri must use HTTPS",
+        ),
+        (
+            _repository(
+                signing_key={
+                    "uri": "https://example.test/key",
+                    "format": "pem",
+                    "digest": KEY_DIGEST,
+                }
+            ),
+            "format",
+        ),
+        (
+            _repository(
+                signing_key={
+                    "uri": "https://example.test/key",
+                    "format": "openpgp-binary",
+                    "digest": "sha256:" + "A" * 64,
+                }
+            ),
+            "digest",
+        ),
+        (_repository(suite="stable main"), "suite must be a bounded APT token"),
+        (_repository(components=[]), "components must contain at least one APT component"),
+        (_repository(components=["main", "main"]), "components must not contain duplicates"),
+        (_repository(components=["main;deb"]), "component must be a bounded APT token"),
+        (_repository(options={"trusted": "yes"}), "Extra inputs are not permitted"),
+    ),
+)
+def test_repository_profile_rejects_unsafe_or_ambiguous_input(repository: dict[str, object], message: str) -> None:
+    with pytest.raises(ValidationError, match=message):
+        RuntimePackage.model_validate(_package(repository=repository))
+
+
+@pytest.mark.parametrize(
+    ("package", "message"),
+    (
+        (_package(manager="dnf"), "manager 'apt'"),
+        (_package(name="-oDebug::pkgProblemResolver=yes"), "package name must be a bounded APT token"),
+        (_package(version="4.12.0-1\nmalformed"), "package version must be a bounded APT token"),
+    ),
+)
+def test_repository_bearing_package_rejects_manager_mismatch_and_option_like_tokens(
+    package: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        RuntimePackage.model_validate(package)
+
+
+def test_default_repository_packages_keep_backward_compatible_opaque_metadata() -> None:
+    package = RuntimePackage(
+        manager="vendor manager",
+        name="legacy package",
+        version="version selected downstream",
+        source="opaque provenance; never executable",
+        purl="pkg:generic/legacy",
+    )
+
+    assert package.repository is None
+    assert package.source == "opaque provenance; never executable"
+    assert package.purl == "pkg:generic/legacy"
+
+
+def test_runtime_configuration_rejects_duplicate_package_identity() -> None:
+    with pytest.raises(ValidationError, match="Duplicate runtime package identity 'apt:wazuh-agent:'"):
+        RuntimeConfiguration.model_validate(
+            {
+                "packages": [
+                    _package(version="4.12.0-1"),
+                    _package(version="4.13.0-1", repository=_repository(uri="https://packages.example.test/apt")),
+                ]
+            }
+        )
+
+
+def test_runtime_configuration_allows_same_package_name_for_distinct_identity_dimensions() -> None:
+    runtime = RuntimeConfiguration.model_validate(
+        {
+            "packages": [
+                {"manager": "apt", "name": "agent", "version": "1", "architecture": "amd64"},
+                {"manager": "apt", "name": "agent", "version": "1", "architecture": "arm64"},
+                {"manager": "apk", "name": "agent", "version": "1", "architecture": "amd64"},
+            ]
+        }
+    )
+
+    assert len(runtime.packages) == 3
+
+
+def test_instantiation_revalidates_bound_repository_values_without_echoing_them() -> None:
+    scenario = parse_sdl(
+        f"""
+name: variable-repository
+variables:
+  repository_uri:
+    type: string
+    default: https://packages.example.test/apt
+nodes:
+  worker:
+    type: compute
+    resources: {{ram: 1 gib, cpu: 1}}
+    runtime:
+      packages:
+        - manager: apt
+          name: agent
+          version: "1"
+          repository:
+            repository_profile: apt
+            profile_version: "1"
+            uri: ${{repository_uri}}
+            suite: stable
+            components: [main]
+            signing_key:
+              uri: https://packages.example.test/key
+              format: openpgp-binary
+              digest: {KEY_DIGEST}
+"""
+    )
+    unsafe_value = "http://user:password@example.test/apt"
+
+    with pytest.raises(SDLInstantiationError, match="Bound scenario is invalid") as caught:
+        instantiate_scenario(scenario, {"repository_uri": unsafe_value})
+
+    assert unsafe_value not in str(caught.value)
+
+
+def test_live_and_published_schemas_expose_the_same_closed_repository_contract() -> None:
+    live = schema_bundle()["sdl-authoring-input-v1"]
+    live_repository = live["$defs"]["RuntimePackage"]["properties"]["repository"]
+
+    assert "RuntimeAptPackageRepository" in json.dumps(live_repository)
+    for schema_path in SCHEMA_PATHS:
+        published = json.loads(schema_path.read_text(encoding="utf-8"))
+        package_schema = published["$defs"]["RuntimePackage"]
+        repository_schema = package_schema["properties"]["repository"]
+        assert repository_schema == live_repository
+        assert package_schema["properties"]["source"]["description"].startswith("Opaque")
+        Draft202012Validator(published).check_schema(published)
+
+
+@pytest.mark.parametrize(
+    ("target", "unsafe_uri"),
+    (
+        ("repository", "http://packages.example.test/apt"),
+        ("repository", "https://user:password@example.test/apt"),
+        ("repository", "https://packages.example.test/apt#stable"),
+        ("signing_key", "https://keys.example.test/vendor?access_token=secret"),
+    ),
+)
+def test_live_schema_rejects_unsafe_repository_uris(target: str, unsafe_uri: str) -> None:
+    scenario = parse_sdl((FIXTURE_ROOT / "valid" / "wazuh.yaml").read_text(encoding="utf-8"))
+    payload = scenario.model_dump(mode="json", by_alias=True)
+    repository = payload["nodes"]["manager"]["runtime"]["packages"][0]["repository"]
+    if target == "repository":
+        repository["uri"] = unsafe_uri
+    else:
+        repository["signing_key"]["uri"] = unsafe_uri
+
+    assert not Draft202012Validator(schema_bundle()["sdl-authoring-input-v1"]).is_valid(payload)
+
+
+def test_invalid_unpinned_key_fixture_fails_at_the_typed_contract_boundary() -> None:
+    source = (FIXTURE_ROOT / "invalid" / "unpinned-key.yaml").read_text(encoding="utf-8")
+
+    with pytest.raises(SDLParseError, match="digest"):
+        parse_sdl(source)


### PR DESCRIPTION
## Plain-language summary

- **Context:** Runtime packages can identify a package source but have no typed way to describe a third-party package repository and its verification key.
- **Problem:** Downstream backends cannot reliably realize vendor packages such as Wazuh from the SDL without relying on undocumented source encodings.
- **Fix:** Add a closed, versioned APT repository profile with credential-free HTTPS locations and SHA-256-pinned public signing keys, while keeping repository realization under the existing runtime-packages authority.

## Issue tracking

Closes #847

## Verification

- Canonical `verify-completion` and repository policy gates passed.
- Focused and adjacent pytest runs passed: 367 passed, 1 skipped; the final focused runtime run passed 184 tests.
- Schema generation, publication, and JSON checks passed.
- Ruff formatting and lint checks passed.
- Code and test-quality reviews completed cleanly with no findings.

## Summary

Add a closed, versioned APT repository profile to RuntimePackage so downstream backends can realize vendor packages from credential-free HTTPS repositories with SHA-256-pinned public signing keys, while preserving existing default-repository packages and the existing runtime-packages authority.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #847

## ADR Impact

- ADR-021

## Changes

- Define the apt/1 repository and public signing-key models with closed URI, digest, token, manager, and duplicate-identity validation.
- Carry repository declarations through parsing, instantiation, compilation, and the existing runtime-packages projection without adding a second realization concern.
- Publish matching schemas, fixtures, documentation, and SEM-218 traceability.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Canonical verify-completion and repository policy passed. Focused and adjacent pytest runs passed (367 passed, 1 skipped), followed by a final focused runtime run (184 passed). Schema generation, publication, and JSON gates passed; Ruff formatting and lint checks passed. The code and test-quality reviews were both clean.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: Issue #847 ← implementations/python/packages/raes/runtime_packages.py, SEM-218 ← implementations/python/packages/raes/runtime_configuration.py
- TESTS: Issue #847 / SEM-218 ← implementations/python/tests/test_issue_847_runtime_package_repositories.py

## Checklist

- [x] Code follows the project's coding standards
- [x] FM level classified for the semantic contract change
- [x] Published contract schemas regenerated
- [x] PR title is a Conventional Commit
- [x] Changelog is owned by Release Please; no per-PR fragment is needed
- [x] Architectural documentation updated

## Documentation

Updated: see diff.

## Notes for review

The repository profile is intentionally limited to APT version 1. Additional package managers require their own discriminated profiles.
