### PR TITLE
test(governance): isolate the gate tests from the CI pull-request refs

### DIFF
--- a/implementations/python/tests/test_issue_1204_repository_governance.py
+++ b/implementations/python/tests/test_issue_1204_repository_governance.py
@@ -3,6 +3,20 @@
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def repository_governance_environment(monkeypatch):
+    """Keep the gate's decisions sourced from the repository under test.
+
+    ``check_requirement_governance`` reads the GitHub Actions pull-request refs
+    to recognise a dev-to-main promotion and to recover the branch from a
+    detached PR checkout. Left in place, the workflow's own refs decide these
+    tests: a promotion pull request exempts every governed path and the gate
+    stops before it inspects the fixture repository at all.
+    """
+    for name in ("GITHUB_HEAD_REF", "GITHUB_BASE_REF"):
+        monkeypatch.delenv(name, raising=False)
+
+
 @pytest.fixture
 def merging_repository(tmp_path):
     import subprocess
@@ -84,6 +98,22 @@ def test_merge_governance_preserves_the_staged_boundary(merging_repository, monk
         monkeypatch.setattr("sys.argv", ["check", "--requirement-uid", "ASR-532", *flags])
         assert gate.main() == 0
         assert ("implementations/incoming.py" in observed) is includes_unstaged
+
+
+def test_dev_to_main_promotion_exempts_the_merge_diff(merging_repository, monkeypatch):
+    from tools import check_requirement_governance as gate
+
+    root, _git, _write = merging_repository
+    observed = []
+    monkeypatch.setattr(gate, "REPO_ROOT", root)
+    monkeypatch.setattr(
+        gate, "evaluate_configured_governance", lambda paths, *_args, **_kwargs: observed.extend(paths) or 0
+    )
+    monkeypatch.setenv("GITHUB_HEAD_REF", "dev")
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+    monkeypatch.setattr("sys.argv", ["check", "--requirement-uid", "ASR-532"])
+    assert gate.main() == 0
+    assert observed == []
 
 
 @pytest.mark.parametrize("staged", [False, True])


### PR DESCRIPTION
## Plain-language summary

- **Context:** `tools/check_requirement_governance.py` reads `GITHUB_HEAD_REF` and `GITHUB_BASE_REF` — to recognise a dev-to-main promotion pull request (`is_dev_to_main_promotion`) and to recover the branch from a detached PR checkout (`current_branch`). GitHub Actions sets both refs on every `pull_request` run.
- **Problem:** `tests/test_issue_1204_repository_governance.py` drives `gate.main()` but never neutralised those refs, so the ambient workflow decided the outcome. On PR #1258 (dev → main) the gate saw a promotion, returned `0` before selecting any path, and nine tests asserting the governed merge diff observed an empty set. The same commits passed on pull requests into dev, where `GITHUB_BASE_REF` is `dev`. All four CPython compatibility jobs failed on #1258 for this reason; the gate itself is behaving as designed.
- **Fix:** An autouse fixture deletes both refs for the module, so the gate decides from the fixture repository rather than the job. A new test pins the promotion exemption explicitly — setting the refs itself and asserting `main()` governs nothing — so the behaviour is asserted rather than inherited from CI.

## Issue tracking

No issue: test-only hermeticity defect in a single module, surfaced directly by the failing checks on #1258.

## Verification

- `uv run --frozen python -m pytest tests/test_issue_1204_repository_governance.py tests/test_requirement_governance.py -q` under `GITHUB_HEAD_REF=dev GITHUB_BASE_REF=main`, under `GITHUB_HEAD_REF=feat GITHUB_BASE_REF=dev`, and with both unset: 59 passed in each case (before the change, the promotion environment produced 9 failures).
- `nox -s hook-pre-commit -- implementations/python/tests/test_issue_1204_repository_governance.py`: passed (hygiene, policy, ruff format, ruff check, module tests).
- Negative control: with `is_dev_to_main_promotion` forced to `False`, the new `test_dev_to_main_promotion_exempts_the_merge_diff` fails, confirming it exercises the exemption.

## Checklist

- [x] Code follows the [project coding standards](../docs/explain/reference/coding-standards.md)
- [x] FM level classified if semantic change — not applicable; test-only change, no runtime semantics touched
- [x] Published contract schemas regenerated if models changed — not applicable
- [x] PR title is a Conventional Commit (release-please derives the version and `CHANGELOG.md` from it)
- [x] Architectural docs updated if applicable — not applicable

## Notes for review

`tools/check_requirement_governance.py` is unchanged. The promotion exemption added in `464d6fee` is correct; only the tests around it were coupled to the CI environment. The repository has no `conftest.py`, so the isolation lives as a module-level autouse fixture alongside the tests it protects.

https://claude.ai/code/session_013K7weUkvsBbkPVvrx5EqiK
