### PR TITLE
test(runtime): wait for driver outcomes instead of a fixed tick budget

### DIFF
--- a/implementations/python/tests/test_dsl_437_benign_participant_execution.py
+++ b/implementations/python/tests/test_dsl_437_benign_participant_execution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 
@@ -84,6 +85,24 @@ def _advance_stepped_clock_to_tick(manager: RuntimeManager, target_tick: int) ->
         assert advanced.success
         current_tick += SCENARIO_CLOCK_STEP_TICKS
     return advanced
+
+
+# The real-time clock driver advances on wall-clock ticks, so how long a driver
+# outcome takes is a property of the runner, not of the semantics under test.
+# The verify lane runs the suite under coverage tracing on a contended host,
+# where a driver thread is descheduled well past its nominal tick period. The
+# waits below poll for the outcome and return the moment it holds, so this
+# budget only ever changes the failing case: a driver that never recomputes
+# still fails the following assertion, while one that is merely slow does not.
+_DRIVER_OUTCOME_BUDGET_SECONDS = 15.0
+
+
+def _await_driver_outcome(condition: Callable[[], bool]) -> None:
+    """Wait for one real-time driver outcome without pinning it to the tick period."""
+
+    deadline = time.monotonic() + _DRIVER_OUTCOME_BUDGET_SECONDS
+    while not condition() and time.monotonic() < deadline:
+        time.sleep(0.01)
 
 
 def _scenario_yaml(*, role: str = "green") -> str:
@@ -1987,9 +2006,7 @@ def test_runtime_manager_automatically_drives_wall_paced_participant_clock() -> 
     manager = RuntimeManager(target)
 
     applied = manager.apply(manager.plan(scenario))
-    deadline = time.monotonic() + 1.0
-    while len(participant_runtime.native_actions) < 2 and time.monotonic() < deadline:
-        time.sleep(0.01)
+    _await_driver_outcome(lambda: len(participant_runtime.native_actions) >= 2)
 
     assert applied.success
     assert len(participant_runtime.native_actions) == 2
@@ -2079,9 +2096,7 @@ def test_wall_driver_recomputes_after_pause_and_resume() -> None:
     time.sleep(0.25)
     assert manager.read_time_state().clocks[policy.clock_address].coordinate.tick == 0
     assert manager.resume_time(policy.clock_address).success
-    deadline = time.monotonic() + 1.0
-    while len(participant_runtime.native_actions) < 2 and time.monotonic() < deadline:
-        time.sleep(0.01)
+    _await_driver_outcome(lambda: len(participant_runtime.native_actions) >= 2)
 
     assert len(participant_runtime.native_actions) == 2
     assert manager.participant_clock_driver_status()["failure"] is None
@@ -2213,9 +2228,7 @@ def test_wall_driver_records_an_unexpected_runtime_exception() -> None:
         lock=threading.RLock(),
     )
     driver.start()
-    deadline = time.monotonic() + 1.0
-    while driver.failure is None and time.monotonic() < deadline:
-        time.sleep(0.01)
+    _await_driver_outcome(lambda: driver.failure is not None)
 
     assert driver.failure is not None
     assert driver.failure.diagnostics[0].code == "runtime.participant-clock-driver-failed"


### PR DESCRIPTION
## Plain-language summary

- **Context:** #1258 (`dev` → `main`) failed `canonical / verify` on `test_wall_driver_recomputes_after_pause_and_resume` with `assert 1 == 2`.
- **Problem:** Not a regression. Commit `106b195e` ran `canonical / verify` **twice**: run [34718630169](https://github.com/OpenRAE/rae/actions/runs/34718630169) passed, run [34718632127](https://github.com/OpenRAE/rae/actions/runs/34718632127) failed — same code, opposite outcomes. All eight CPython compatibility jobs on that commit passed. The test resumes a real-time clock driver with a 0.2s tick period and allows a fixed **1.0 second** for two ticks: five tick periods of slack. `canonical / verify` runs pytest with `--cov` across parallel lanes; the compatibility jobs do not. Under coverage tracing on a contended host the driver thread is descheduled past that budget and the test observes one action instead of two.
- **Fix:** How long a driver outcome takes is a property of the runner, not of the semantics under test. All three fixed-budget waits in the module now share one `_await_driver_outcome` helper that polls and returns the instant the condition holds.

Because the loop exits as soon as the outcome lands, a larger budget costs nothing in a healthy run — it changes only the failing case. A driver that never recomputes still fails the assertion that follows; one that is merely slow no longer does. The assertions themselves are untouched, so an over-producing or non-recomputing driver is still caught exactly as before.

Two sibling waits at the same 1.0s budget (the initial-actions wait and the driver-failure wait) were the same latent flake and are converted too.

## Issue tracking

No issue: test-only flake remediation for the failure blocking #1258, diagnosed to its cause.

## Verification

Reproduced and fixed under the conditions the verify lane creates — pytest with `--cov`, host loaded to twice its core count:

| Budget | Runs | Result |
| --- | --- | --- |
| 1.0s (before) | 2 | **both failed** |
| 15.0s (after) | 2 | **both passed** (55–76s wall time) |

So the failure is reproducible on demand with the old budget and does not occur with the new one — the change is demonstrably what alters the outcome.

- `pytest tests/test_dsl_437_benign_participant_execution.py -q`: 61 passed.
- `nox -s hook-pre-commit -- implementations/python/tests/test_dsl_437_benign_participant_execution.py`: passed.

## Checklist

- [x] Code follows the [project coding standards](../docs/explain/reference/coding-standards.md)
- [x] FM level classified if semantic change — not applicable; test-only, no runtime code touched
- [x] Published contract schemas regenerated if models changed — not applicable
- [x] PR title is a Conventional Commit (release-please derives the version and `CHANGELOG.md` from it)
- [x] Architectural docs updated if applicable — not applicable

## Notes for review

A fake clock would make these tests fully deterministic, but `advancement_mode: real_time` and the wall driver are precisely what they exercise — substituting the clock would delete the subject. Polling with a generous budget is the right shape for a real-time component.

15s is deliberately far above the ~0.4s the work needs, so the budget stops being a variable. The only cost is that a genuinely broken driver takes that long to fail.

https://claude.ai/code/session_013K7weUkvsBbkPVvrx5EqiK
