### PR TITLE
feat: add typed partial realization descriptions

### DIFF
--- a/contracts/fixtures/experiment-core/experiment-evidence-record-v1/invalid/withheld-description-value.json
+++ b/contracts/fixtures/experiment-core/experiment-evidence-record-v1/invalid/withheld-description-value.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "experiment-evidence-record/v1",
+  "evidence_record_id": "evidence-techvault-network-trace-001",
+  "record_version": "1.0.0",
+  "capture_spec_ref": {
+    "ref_kind": "capture-spec",
+    "ref_id": "capture-techvault-evidence-v1",
+    "ref_version": "1.0.0"
+  },
+  "capture_requirement_ref": "network-trace",
+  "output_contract": "participant-behavior-history-event-stream-v1",
+  "run_ref": {
+    "ref_kind": "run",
+    "ref_id": "run-techvault-001",
+    "ref_version": "1.0.0"
+  },
+  "task_ref": {
+    "ref_kind": "task",
+    "ref_id": "task-techvault-red-team-v1",
+    "ref_version": "1.0.0"
+  },
+  "source_refs": [
+    {
+      "ref_kind": "measurement-channel",
+      "ref_id": "evaluation-history-channel",
+      "ref_version": "1.0.0"
+    }
+  ],
+  "evidence_kind": "trace",
+  "captured_at": "2026-05-26T00:40:00Z",
+  "capture_window_ref": "run-window",
+  "raw_content": {
+    "content_uri": "runs/run-techvault-001/evaluation-history.json",
+    "content_checksum": {
+      "algorithm": "sha256",
+      "value": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "payload_summary": "Evaluation history export containing the observed foothold event."
+  },
+  "sensitivity": "internal",
+  "redaction_state": "none",
+  "provenance_refs": [
+    {
+      "ref_kind": "backend",
+      "ref_id": "stub-backend",
+      "ref_version": "0.1.0"
+    }
+  ],
+  "typed_description": {
+    "schema_version": "realization-description/v1",
+    "description_id": "capture-1",
+    "description_version": "1",
+    "semantic_profile": "example-state/v1",
+    "authored_ref": {
+      "ref_kind": "scenario",
+      "ref_id": "original",
+      "ref_version": "1",
+      "ref_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "provenance": {
+      "observer_ref": {
+        "ref_kind": "backend",
+        "ref_id": "example",
+        "ref_version": "1"
+      },
+      "recorded_at": "2026-09-12T10:00:00Z",
+      "basis": "backend-selected",
+      "window_ref": "selection-1"
+    },
+    "facts": [
+      {
+        "fact_id": "family",
+        "subject": "/nodes/a/family",
+        "state": "withheld",
+        "value": {
+          "kind": "literal",
+          "value": "linux",
+          "origin": "backend"
+        }
+      },
+      {
+        "fact_id": "release",
+        "subject": "/nodes/a/release",
+        "state": "not-observed"
+      },
+      {
+        "fact_id": "absent",
+        "subject": "/nodes/a/optional",
+        "state": "known-absent"
+      },
+      {
+        "fact_id": "private",
+        "subject": "/nodes/a/private",
+        "state": "withheld",
+        "limitations": [
+          "Not disclosed under the selected policy."
+        ]
+      }
+    ],
+    "coverage": [
+      {
+        "subject": "/nodes/a",
+        "kind": "field",
+        "universe": "node-fields/v1",
+        "profile": "example-state/v1",
+        "status": "partial",
+        "fact_ids": [
+          "family",
+          "release",
+          "absent",
+          "private"
+        ]
+      }
+    ]
+  }
+}

--- a/contracts/fixtures/experiment-core/experiment-evidence-record-v1/valid/partial-description.json
+++ b/contracts/fixtures/experiment-core/experiment-evidence-record-v1/valid/partial-description.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "experiment-evidence-record/v1",
+  "evidence_record_id": "evidence-techvault-network-trace-001",
+  "record_version": "1.0.0",
+  "capture_spec_ref": {
+    "ref_kind": "capture-spec",
+    "ref_id": "capture-techvault-evidence-v1",
+    "ref_version": "1.0.0"
+  },
+  "capture_requirement_ref": "network-trace",
+  "output_contract": "participant-behavior-history-event-stream-v1",
+  "run_ref": {
+    "ref_kind": "run",
+    "ref_id": "run-techvault-001",
+    "ref_version": "1.0.0"
+  },
+  "task_ref": {
+    "ref_kind": "task",
+    "ref_id": "task-techvault-red-team-v1",
+    "ref_version": "1.0.0"
+  },
+  "source_refs": [
+    {
+      "ref_kind": "measurement-channel",
+      "ref_id": "evaluation-history-channel",
+      "ref_version": "1.0.0"
+    }
+  ],
+  "evidence_kind": "trace",
+  "captured_at": "2026-05-26T00:40:00Z",
+  "capture_window_ref": "run-window",
+  "raw_content": {
+    "content_uri": "runs/run-techvault-001/evaluation-history.json",
+    "content_checksum": {
+      "algorithm": "sha256",
+      "value": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "payload_summary": "Evaluation history export containing the observed foothold event."
+  },
+  "sensitivity": "internal",
+  "redaction_state": "none",
+  "provenance_refs": [
+    {
+      "ref_kind": "backend",
+      "ref_id": "stub-backend",
+      "ref_version": "0.1.0"
+    }
+  ],
+  "typed_description": {
+    "schema_version": "realization-description/v1",
+    "description_id": "capture-1",
+    "description_version": "1",
+    "semantic_profile": "example-state/v1",
+    "authored_ref": {
+      "ref_kind": "scenario",
+      "ref_id": "original",
+      "ref_version": "1",
+      "ref_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "provenance": {
+      "observer_ref": {
+        "ref_kind": "backend",
+        "ref_id": "example",
+        "ref_version": "1"
+      },
+      "recorded_at": "2026-09-12T10:00:00Z",
+      "basis": "backend-selected",
+      "window_ref": "selection-1"
+    },
+    "facts": [
+      {
+        "fact_id": "family",
+        "subject": "/nodes/a/family",
+        "state": "known",
+        "value": {
+          "kind": "literal",
+          "value": "linux",
+          "origin": "backend"
+        }
+      },
+      {
+        "fact_id": "release",
+        "subject": "/nodes/a/release",
+        "state": "not-observed"
+      },
+      {
+        "fact_id": "absent",
+        "subject": "/nodes/a/optional",
+        "state": "known-absent"
+      },
+      {
+        "fact_id": "private",
+        "subject": "/nodes/a/private",
+        "state": "withheld",
+        "limitations": [
+          "Not disclosed under the selected policy."
+        ]
+      }
+    ],
+    "coverage": [
+      {
+        "subject": "/nodes/a",
+        "kind": "field",
+        "universe": "node-fields/v1",
+        "profile": "example-state/v1",
+        "status": "partial",
+        "fact_ids": [
+          "family",
+          "release",
+          "absent",
+          "private"
+        ]
+      }
+    ]
+  }
+}

--- a/contracts/schema-publication/entries/experiment-evidence-record-v1.json
+++ b/contracts/schema-publication/entries/experiment-evidence-record-v1.json
@@ -2,9 +2,9 @@
   "contract_id": "experiment-evidence-record-v1",
   "schema_path": "contracts/schemas/experiment-core/experiment-evidence-record-v1.json",
   "stability": "draft",
-  "content_hash": "2b52c1c7fa28fa939aa3b1baeee830522ffc0467eda945e0857b504c5a7df43c",
+  "content_hash": "582402d01e9d6af721d8df20cedfd40096df6e580bd4231e01b2544d37113196",
   "last_change": {
-    "summary": "Bound emitted evidence records to their required output contract and exact redaction policy for issue #1112.",
-    "content_hash": "2b52c1c7fa28fa939aa3b1baeee830522ffc0467eda945e0857b504c5a7df43c"
+    "summary": "Carry non-authoritative partial typed descriptions, coverage and provenance in the existing lifecycle envelope (#1209).",
+    "content_hash": "582402d01e9d6af721d8df20cedfd40096df6e580bd4231e01b2544d37113196"
   }
 }

--- a/contracts/schema-publication/entries/experiment-run-v1.json
+++ b/contracts/schema-publication/entries/experiment-run-v1.json
@@ -2,9 +2,9 @@
   "contract_id": "experiment-run-v1",
   "schema_path": "contracts/schemas/experiment-core/experiment-run-v1.json",
   "stability": "draft",
-  "content_hash": "e793727d1562c90aa175ee0175fbf7db5003c9f06d12971c9acf1257d0327d75",
+  "content_hash": "4418e91520fcd2b76eab25923508a95275e2c59d9d4c34f2fe64701c6a3d2fd7",
   "last_change": {
-    "summary": "Separated structural task/run validation from authoritative content-backed evidence satisfaction for issue #1112.",
-    "content_hash": "e793727d1562c90aa175ee0175fbf7db5003c9f06d12971c9acf1257d0327d75"
+    "summary": "Carry non-authoritative partial typed descriptions, coverage and provenance in the existing lifecycle envelope (#1209).",
+    "content_hash": "4418e91520fcd2b76eab25923508a95275e2c59d9d4c34f2fe64701c6a3d2fd7"
   }
 }

--- a/contracts/schemas/experiment-core/experiment-evidence-record-v1.json
+++ b/contracts/schemas/experiment-core/experiment-evidence-record-v1.json
@@ -1,5 +1,654 @@
 {
   "$defs": {
+    "BooleanDomain": {
+      "additionalProperties": false,
+      "description": "Booleans: both ``true``/``false``, or an exact boolean when ``value`` set.",
+      "properties": {
+        "kind": {
+          "const": "boolean",
+          "default": "boolean",
+          "title": "Kind",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value"
+        }
+      },
+      "title": "BooleanDomain",
+      "type": "object"
+    },
+    "DescriptionCoverageModel": {
+      "additionalProperties": false,
+      "description": "Enumeration coverage in a named universe; never author collection closure.",
+      "properties": {
+        "fact_ids": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 4096,
+          "title": "Fact Ids",
+          "type": "array"
+        },
+        "kind": {
+          "enum": [
+            "field",
+            "collection"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 256,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "profile": {
+          "minLength": 1,
+          "title": "Profile",
+          "type": "string"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DescriptionProvenanceModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "recursive": {
+          "default": false,
+          "title": "Recursive",
+          "type": "boolean"
+        },
+        "status": {
+          "enum": [
+            "partial",
+            "complete",
+            "not-observed",
+            "withheld"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "subject": {
+          "maxLength": 4096,
+          "pattern": "^(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Subject",
+          "type": "string"
+        },
+        "universe": {
+          "minLength": 1,
+          "title": "Universe",
+          "type": "string"
+        }
+      },
+      "required": [
+        "subject",
+        "kind",
+        "universe",
+        "profile",
+        "status"
+      ],
+      "title": "DescriptionCoverageModel",
+      "type": "object"
+    },
+    "DescriptionFactModel": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "else": {
+            "properties": {
+              "profile_bindings": {
+                "maxItems": 0
+              },
+              "value": {
+                "type": "null"
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "state": {
+                "const": "known"
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "value"
+            ]
+          }
+        }
+      ],
+      "description": "One assertion; different sources at the same subject remain separate facts.",
+      "properties": {
+        "component_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Component Ref"
+        },
+        "fact_id": {
+          "minLength": 1,
+          "title": "Fact Id",
+          "type": "string"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 256,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "profile_bindings": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DomainProfileBindingModel"
+          },
+          "maxItems": 256,
+          "title": "Profile Bindings",
+          "type": "array"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DescriptionProvenanceModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "state": {
+          "enum": [
+            "known",
+            "not-observed",
+            "known-absent",
+            "withheld",
+            "contradictory",
+            "not-applicable"
+          ],
+          "title": "State",
+          "type": "string"
+        },
+        "subject": {
+          "maxLength": 4096,
+          "pattern": "^(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Subject",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "all-of": "#/$defs/RealizationAllOf",
+                  "definition-reference": "#/$defs/RealizationDefinitionReference",
+                  "delegated": "#/$defs/RealizationDelegatedValue",
+                  "domain": "#/$defs/RealizationDomainValue",
+                  "graph-reference": "#/$defs/RealizationGraphReference",
+                  "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+                  "knowledge": "#/$defs/RealizationKnowledgeValue",
+                  "literal": "#/$defs/RealizationLiteral",
+                  "recursive-record": "#/$defs/RealizationRecordConstraint",
+                  "sequence": "#/$defs/RealizationSequenceConstraint"
+                },
+                "propertyName": "kind"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/RealizationLiteral"
+                },
+                {
+                  "$ref": "#/$defs/RealizationKnowledgeValue"
+                },
+                {
+                  "$ref": "#/$defs/RealizationDelegatedValue"
+                },
+                {
+                  "$ref": "#/$defs/RealizationDomainValue"
+                },
+                {
+                  "$ref": "#/$defs/RealizationRecordConstraint"
+                },
+                {
+                  "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+                },
+                {
+                  "$ref": "#/$defs/RealizationSequenceConstraint"
+                },
+                {
+                  "$ref": "#/$defs/RealizationDefinitionReference"
+                },
+                {
+                  "$ref": "#/$defs/RealizationGraphReference"
+                },
+                {
+                  "$ref": "#/$defs/RealizationAllOf"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value"
+        }
+      },
+      "required": [
+        "fact_id",
+        "subject",
+        "state"
+      ],
+      "title": "DescriptionFactModel",
+      "type": "object"
+    },
+    "DescriptionProvenanceModel": {
+      "additionalProperties": false,
+      "description": "Actual source and basis, inherited unless a fact explicitly overrides it.",
+      "properties": {
+        "basis": {
+          "$ref": "#/$defs/ObservationBasis"
+        },
+        "configuration_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ExperimentReferenceModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "evidence_refs": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ExperimentReferenceModel"
+          },
+          "maxItems": 256,
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "observer_ref": {
+          "$ref": "#/$defs/ExperimentReferenceModel"
+        },
+        "operation_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ExperimentReferenceModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "recorded_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Recorded At",
+          "type": "string"
+        },
+        "window_ref": {
+          "minLength": 1,
+          "title": "Window Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "observer_ref",
+        "recorded_at",
+        "basis",
+        "window_ref"
+      ],
+      "title": "DescriptionProvenanceModel",
+      "type": "object"
+    },
+    "DomainProfileBindingBasis": {
+      "enum": [
+        "author-supplied",
+        "backend-selected",
+        "observed"
+      ],
+      "title": "DomainProfileBindingBasis",
+      "type": "string"
+    },
+    "DomainProfileBindingModel": {
+      "additionalProperties": false,
+      "description": "Typed profile data attached to one explicit host owner.",
+      "properties": {
+        "binding_id": {
+          "maxLength": 128,
+          "pattern": "^[a-z][a-z0-9]*(?:[-.][a-z0-9]+)*$",
+          "title": "Binding Id",
+          "type": "string"
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DomainProfileBindingModel"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "coordinate": {
+          "$ref": "#/$defs/DomainProfileCoordinateModel"
+        },
+        "owner": {
+          "$ref": "#/$defs/DomainProfileBindingOwnerModel"
+        },
+        "provenance": {
+          "$ref": "#/$defs/DomainProfileBindingProvenanceModel"
+        },
+        "schema_version": {
+          "const": "domain-profile-binding/v1",
+          "default": "domain-profile-binding/v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        }
+      },
+      "required": [
+        "binding_id",
+        "coordinate",
+        "owner",
+        "value",
+        "provenance"
+      ],
+      "title": "DomainProfileBindingModel",
+      "type": "object"
+    },
+    "DomainProfileBindingOwnerModel": {
+      "additionalProperties": false,
+      "description": "Explicit core owner, phase, context, and use for profile data.",
+      "properties": {
+        "canonical_address": {
+          "maxLength": 4096,
+          "pattern": "^#(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Canonical Address",
+          "type": "string"
+        },
+        "concept_family": {
+          "minLength": 1,
+          "title": "Concept Family",
+          "type": "string"
+        },
+        "context": {
+          "minLength": 1,
+          "title": "Context",
+          "type": "string"
+        },
+        "lifecycle_phase": {
+          "minLength": 1,
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
+        "owning_contract_id": {
+          "minLength": 1,
+          "title": "Owning Contract Id",
+          "type": "string"
+        },
+        "use": {
+          "$ref": "#/$defs/DomainProfileBindingUse"
+        }
+      },
+      "required": [
+        "owning_contract_id",
+        "canonical_address",
+        "concept_family",
+        "lifecycle_phase",
+        "context",
+        "use"
+      ],
+      "title": "DomainProfileBindingOwnerModel",
+      "type": "object"
+    },
+    "DomainProfileBindingProvenanceModel": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "basis": {
+                "const": "observed"
+              }
+            },
+            "required": [
+              "basis"
+            ]
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 1
+              }
+            },
+            "required": [
+              "evidence_refs"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "basis": {
+                "enum": [
+                  "author-supplied",
+                  "backend-selected"
+                ]
+              }
+            },
+            "required": [
+              "basis"
+            ]
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ],
+      "description": "Basis of a bound value, separate from definition trust provenance.",
+      "properties": {
+        "basis": {
+          "$ref": "#/$defs/DomainProfileBindingBasis"
+        },
+        "evidence_refs": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "source_ref": {
+          "minLength": 1,
+          "title": "Source Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "basis",
+        "source_ref"
+      ],
+      "title": "DomainProfileBindingProvenanceModel",
+      "type": "object"
+    },
+    "DomainProfileBindingUse": {
+      "enum": [
+        "constraint",
+        "typed-report",
+        "annotation",
+        "opaque-exchange"
+      ],
+      "title": "DomainProfileBindingUse",
+      "type": "string"
+    },
+    "DomainProfileCoordinateModel": {
+      "additionalProperties": false,
+      "description": "Exact immutable definition coordinate.",
+      "properties": {
+        "authority": {
+          "minLength": 1,
+          "title": "Authority",
+          "type": "string"
+        },
+        "definition_digest": {
+          "minLength": 1,
+          "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+          "title": "Definition Digest",
+          "type": "string"
+        },
+        "namespace": {
+          "maxLength": 253,
+          "pattern": "^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$",
+          "title": "Namespace",
+          "type": "string"
+        },
+        "profile_id": {
+          "maxLength": 128,
+          "pattern": "^[a-z][a-z0-9]*(?:[-.][a-z0-9]+)*$",
+          "title": "Profile Id",
+          "type": "string"
+        },
+        "revision": {
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$",
+          "title": "Revision",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "authority",
+        "profile_id",
+        "revision",
+        "definition_digest"
+      ],
+      "title": "DomainProfileCoordinateModel",
+      "type": "object"
+    },
+    "EnumDomain": {
+      "additionalProperties": false,
+      "description": "A finite value set: values equal to one listed member.",
+      "properties": {
+        "kind": {
+          "const": "enum",
+          "default": "enum",
+          "title": "Kind",
+          "type": "string"
+        },
+        "values": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "minItems": 1,
+          "title": "Values",
+          "type": "array"
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "title": "EnumDomain",
+      "type": "object"
+    },
+    "ExactDomain": {
+      "additionalProperties": false,
+      "description": "A singleton value set: values equal to ``value``.",
+      "properties": {
+        "kind": {
+          "const": "exact",
+          "default": "exact",
+          "title": "Kind",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "title": "Value"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "title": "ExactDomain",
+      "type": "object"
+    },
     "ExperimentArtifactRefModel": {
       "additionalProperties": false,
       "description": "Reference to an artifact that supports a task, run, apparatus, or study.",
@@ -546,6 +1195,1048 @@
       ],
       "title": "ExperimentTaskReferenceModel",
       "type": "object"
+    },
+    "GovernedReferenceDomain": {
+      "additionalProperties": false,
+      "description": "References in a finite governed set under a named authority.",
+      "properties": {
+        "allowed_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Allowed Refs",
+          "type": "array"
+        },
+        "authority": {
+          "minLength": 1,
+          "title": "Authority",
+          "type": "string"
+        },
+        "kind": {
+          "const": "governed-reference",
+          "default": "governed-reference",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "allowed_refs"
+      ],
+      "title": "GovernedReferenceDomain",
+      "type": "object"
+    },
+    "JsonValue": {},
+    "NullDomain": {
+      "additionalProperties": false,
+      "description": "The singleton JSON-null domain, distinct from omission or unknown.",
+      "properties": {
+        "kind": {
+          "const": "null",
+          "default": "null",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "title": "NullDomain",
+      "type": "object"
+    },
+    "NumericIntervalDomain": {
+      "additionalProperties": false,
+      "description": "Numbers of ``numeric_type`` inside a bounded interval.\n\nBoth endpoints are required (the fragment admits only *bounded* intervals,\n``envelope-semantics.md`` R3). An integer interval requires integral\nendpoints. Empty intervals are rejected at construction.",
+      "properties": {
+        "kind": {
+          "const": "numeric-interval",
+          "default": "numeric-interval",
+          "title": "Kind",
+          "type": "string"
+        },
+        "lower": {
+          "title": "Lower",
+          "type": "number"
+        },
+        "lower_closed": {
+          "default": true,
+          "title": "Lower Closed",
+          "type": "boolean"
+        },
+        "numeric_type": {
+          "$ref": "#/$defs/NumericType"
+        },
+        "upper": {
+          "title": "Upper",
+          "type": "number"
+        },
+        "upper_closed": {
+          "default": true,
+          "title": "Upper Closed",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "numeric_type",
+        "lower",
+        "upper"
+      ],
+      "title": "NumericIntervalDomain",
+      "type": "object"
+    },
+    "NumericType": {
+      "description": "Declared numeric type for a numeric-interval domain.",
+      "enum": [
+        "integer",
+        "number"
+      ],
+      "title": "NumericType",
+      "type": "string"
+    },
+    "ObservationBasis": {
+      "description": "Truthful basis requested for a reportable value.",
+      "enum": [
+        "backend-selected",
+        "observed",
+        "independently-verified",
+        "operational"
+      ],
+      "title": "ObservationBasis",
+      "type": "string"
+    },
+    "RealizationAllOf": {
+      "additionalProperties": false,
+      "description": "A canonical conjunction used when constraints cannot be safely folded.",
+      "properties": {
+        "constraints": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "all-of": "#/$defs/RealizationAllOf",
+                "definition-reference": "#/$defs/RealizationDefinitionReference",
+                "delegated": "#/$defs/RealizationDelegatedValue",
+                "domain": "#/$defs/RealizationDomainValue",
+                "graph-reference": "#/$defs/RealizationGraphReference",
+                "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+                "knowledge": "#/$defs/RealizationKnowledgeValue",
+                "literal": "#/$defs/RealizationLiteral",
+                "recursive-record": "#/$defs/RealizationRecordConstraint",
+                "sequence": "#/$defs/RealizationSequenceConstraint"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RealizationLiteral"
+              },
+              {
+                "$ref": "#/$defs/RealizationKnowledgeValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDelegatedValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDomainValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationRecordConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationSequenceConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationDefinitionReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationGraphReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationAllOf"
+              }
+            ]
+          },
+          "maxItems": 256,
+          "minItems": 2,
+          "title": "Constraints",
+          "type": "array"
+        },
+        "kind": {
+          "const": "all-of",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "constraints"
+      ],
+      "title": "RealizationAllOf",
+      "type": "object"
+    },
+    "RealizationClosure": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "posture": {
+                "enum": [
+                  "open",
+                  "closed"
+                ]
+              }
+            },
+            "required": [
+              "posture"
+            ]
+          },
+          "then": {
+            "required": [
+              "universe",
+              "profile"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "posture": {
+                "const": "undefined"
+              }
+            },
+            "required": [
+              "posture"
+            ]
+          },
+          "then": {
+            "properties": {
+              "profile": {
+                "type": "null"
+              },
+              "universe": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ],
+      "description": "One local posture in an explicitly named semantic universe.",
+      "properties": {
+        "posture": {
+          "$ref": "#/$defs/RealizationClosurePosture",
+          "default": "undefined"
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Profile"
+        },
+        "universe": {
+          "anyOf": [
+            {
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Universe"
+        }
+      },
+      "title": "RealizationClosure",
+      "type": "object"
+    },
+    "RealizationClosurePosture": {
+      "description": "Local collection or record posture before lexical inheritance.",
+      "enum": [
+        "open",
+        "closed",
+        "undefined"
+      ],
+      "title": "RealizationClosurePosture",
+      "type": "string"
+    },
+    "RealizationCollectionMember": {
+      "additionalProperties": false,
+      "description": "One semantic member identity and its recursive constraint.",
+      "properties": {
+        "constraint": {
+          "discriminator": {
+            "mapping": {
+              "all-of": "#/$defs/RealizationAllOf",
+              "definition-reference": "#/$defs/RealizationDefinitionReference",
+              "delegated": "#/$defs/RealizationDelegatedValue",
+              "domain": "#/$defs/RealizationDomainValue",
+              "graph-reference": "#/$defs/RealizationGraphReference",
+              "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+              "knowledge": "#/$defs/RealizationKnowledgeValue",
+              "literal": "#/$defs/RealizationLiteral",
+              "recursive-record": "#/$defs/RealizationRecordConstraint",
+              "sequence": "#/$defs/RealizationSequenceConstraint"
+            },
+            "propertyName": "kind"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/RealizationLiteral"
+            },
+            {
+              "$ref": "#/$defs/RealizationKnowledgeValue"
+            },
+            {
+              "$ref": "#/$defs/RealizationDelegatedValue"
+            },
+            {
+              "$ref": "#/$defs/RealizationDomainValue"
+            },
+            {
+              "$ref": "#/$defs/RealizationRecordConstraint"
+            },
+            {
+              "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+            },
+            {
+              "$ref": "#/$defs/RealizationSequenceConstraint"
+            },
+            {
+              "$ref": "#/$defs/RealizationDefinitionReference"
+            },
+            {
+              "$ref": "#/$defs/RealizationGraphReference"
+            },
+            {
+              "$ref": "#/$defs/RealizationAllOf"
+            }
+          ],
+          "title": "Constraint"
+        },
+        "identity": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Identity",
+          "type": "array"
+        }
+      },
+      "required": [
+        "identity",
+        "constraint"
+      ],
+      "title": "RealizationCollectionMember",
+      "type": "object"
+    },
+    "RealizationDefinitionReference": {
+      "additionalProperties": false,
+      "description": "A bounded acyclic reference to another constraint definition.",
+      "properties": {
+        "kind": {
+          "const": "definition-reference",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        },
+        "target": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Target",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "target"
+      ],
+      "title": "RealizationDefinitionReference",
+      "type": "object"
+    },
+    "RealizationDelegatedValue": {
+      "additionalProperties": false,
+      "description": "A deliberately backend-selected value, distinct from unknown knowledge.",
+      "properties": {
+        "kind": {
+          "const": "delegated",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "title": "RealizationDelegatedValue",
+      "type": "object"
+    },
+    "RealizationDomainValue": {
+      "additionalProperties": false,
+      "description": "A scalar restricted by the shared bounded-domain algebra.",
+      "properties": {
+        "domain": {
+          "discriminator": {
+            "mapping": {
+              "boolean": "#/$defs/BooleanDomain",
+              "enum": "#/$defs/EnumDomain",
+              "exact": "#/$defs/ExactDomain",
+              "governed-reference": "#/$defs/GovernedReferenceDomain",
+              "null": "#/$defs/NullDomain",
+              "numeric-interval": "#/$defs/NumericIntervalDomain",
+              "record": "#/$defs/RecordDomain"
+            },
+            "propertyName": "kind"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ExactDomain"
+            },
+            {
+              "$ref": "#/$defs/EnumDomain"
+            },
+            {
+              "$ref": "#/$defs/BooleanDomain"
+            },
+            {
+              "$ref": "#/$defs/NullDomain"
+            },
+            {
+              "$ref": "#/$defs/NumericIntervalDomain"
+            },
+            {
+              "$ref": "#/$defs/GovernedReferenceDomain"
+            },
+            {
+              "$ref": "#/$defs/RecordDomain"
+            }
+          ],
+          "title": "Domain"
+        },
+        "kind": {
+          "const": "domain",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "domain"
+      ],
+      "title": "RealizationDomainValue",
+      "type": "object"
+    },
+    "RealizationGraphReference": {
+      "additionalProperties": false,
+      "description": "A graph identity edge; it is compared, never recursively expanded.",
+      "properties": {
+        "cycle_policy": {
+          "enum": [
+            "allow",
+            "forbid"
+          ],
+          "title": "Cycle Policy",
+          "type": "string"
+        },
+        "domain": {
+          "$ref": "#/$defs/GovernedReferenceDomain"
+        },
+        "kind": {
+          "const": "graph-reference",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "domain",
+        "cycle_policy"
+      ],
+      "title": "RealizationGraphReference",
+      "type": "object"
+    },
+    "RealizationIdentityAlias": {
+      "additionalProperties": false,
+      "description": "One explicit alternate identity mapped to a canonical member identity.",
+      "properties": {
+        "identity": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Identity",
+          "type": "array"
+        },
+        "target": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Target",
+          "type": "array"
+        }
+      },
+      "required": [
+        "identity",
+        "target"
+      ],
+      "title": "RealizationIdentityAlias",
+      "type": "object"
+    },
+    "RealizationKeyedCollectionConstraint": {
+      "additionalProperties": false,
+      "description": "A set-like collection matched by profile-owned semantic identity.",
+      "properties": {
+        "aliases": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RealizationIdentityAlias"
+          },
+          "maxItems": 4096,
+          "title": "Aliases",
+          "type": "array"
+        },
+        "closure": {
+          "$ref": "#/$defs/RealizationClosure",
+          "default": {
+            "posture": "undefined",
+            "profile": null,
+            "universe": null
+          }
+        },
+        "collection_kind": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Collection Kind",
+          "type": "string"
+        },
+        "identity_fields": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Identity Fields",
+          "type": "array"
+        },
+        "kind": {
+          "const": "keyed-collection",
+          "title": "Kind",
+          "type": "string"
+        },
+        "max_items": {
+          "default": 4096,
+          "maximum": 4096,
+          "minimum": 0,
+          "title": "Max Items",
+          "type": "integer"
+        },
+        "members": {
+          "items": {
+            "$ref": "#/$defs/RealizationCollectionMember"
+          },
+          "maxItems": 4096,
+          "title": "Members",
+          "type": "array"
+        },
+        "min_items": {
+          "default": 0,
+          "maximum": 4096,
+          "minimum": 0,
+          "title": "Min Items",
+          "type": "integer"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "collection_kind",
+        "identity_fields",
+        "members"
+      ],
+      "title": "RealizationKeyedCollectionConstraint",
+      "type": "object"
+    },
+    "RealizationKnowledgeValue": {
+      "additionalProperties": false,
+      "description": "A value-free knowledge state that never grants realization authority.",
+      "properties": {
+        "kind": {
+          "const": "knowledge",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        },
+        "state": {
+          "enum": [
+            "unknown",
+            "redacted",
+            "not-applicable"
+          ],
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "state"
+      ],
+      "title": "RealizationKnowledgeValue",
+      "type": "object"
+    },
+    "RealizationLiteral": {
+      "additionalProperties": false,
+      "description": "A type-sensitive exact JSON value, including explicit JSON null.",
+      "properties": {
+        "kind": {
+          "const": "literal",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Value"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "title": "RealizationLiteral",
+      "type": "object"
+    },
+    "RealizationOrigin": {
+      "description": "Authority origin retained independently of the represented value.",
+      "enum": [
+        "author",
+        "default",
+        "processor",
+        "backend",
+        "observation"
+      ],
+      "title": "RealizationOrigin",
+      "type": "string"
+    },
+    "RealizationPresence": {
+      "description": "Whether the addressed member must, may, or must not exist.",
+      "enum": [
+        "required",
+        "optional",
+        "forbidden"
+      ],
+      "title": "RealizationPresence",
+      "type": "string"
+    },
+    "RealizationRecordConstraint": {
+      "additionalProperties": false,
+      "description": "A recursive record whose closure is independent of child precision.",
+      "properties": {
+        "closure": {
+          "$ref": "#/$defs/RealizationClosure",
+          "default": {
+            "posture": "undefined",
+            "profile": null,
+            "universe": null
+          }
+        },
+        "fields": {
+          "additionalProperties": {
+            "discriminator": {
+              "mapping": {
+                "all-of": "#/$defs/RealizationAllOf",
+                "definition-reference": "#/$defs/RealizationDefinitionReference",
+                "delegated": "#/$defs/RealizationDelegatedValue",
+                "domain": "#/$defs/RealizationDomainValue",
+                "graph-reference": "#/$defs/RealizationGraphReference",
+                "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+                "knowledge": "#/$defs/RealizationKnowledgeValue",
+                "literal": "#/$defs/RealizationLiteral",
+                "recursive-record": "#/$defs/RealizationRecordConstraint",
+                "sequence": "#/$defs/RealizationSequenceConstraint"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RealizationLiteral"
+              },
+              {
+                "$ref": "#/$defs/RealizationKnowledgeValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDelegatedValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDomainValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationRecordConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationSequenceConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationDefinitionReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationGraphReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationAllOf"
+              }
+            ]
+          },
+          "maxProperties": 4096,
+          "title": "Fields",
+          "type": "object"
+        },
+        "kind": {
+          "const": "recursive-record",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "fields"
+      ],
+      "title": "RealizationRecordConstraint",
+      "type": "object"
+    },
+    "RealizationSequenceConstraint": {
+      "additionalProperties": false,
+      "description": "An ordered collection; position remains meaningful and duplicates survive.",
+      "properties": {
+        "closure": {
+          "$ref": "#/$defs/RealizationClosure",
+          "default": {
+            "posture": "undefined",
+            "profile": null,
+            "universe": null
+          }
+        },
+        "items": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "all-of": "#/$defs/RealizationAllOf",
+                "definition-reference": "#/$defs/RealizationDefinitionReference",
+                "delegated": "#/$defs/RealizationDelegatedValue",
+                "domain": "#/$defs/RealizationDomainValue",
+                "graph-reference": "#/$defs/RealizationGraphReference",
+                "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+                "knowledge": "#/$defs/RealizationKnowledgeValue",
+                "literal": "#/$defs/RealizationLiteral",
+                "recursive-record": "#/$defs/RealizationRecordConstraint",
+                "sequence": "#/$defs/RealizationSequenceConstraint"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RealizationLiteral"
+              },
+              {
+                "$ref": "#/$defs/RealizationKnowledgeValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDelegatedValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDomainValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationRecordConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationSequenceConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationDefinitionReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationGraphReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationAllOf"
+              }
+            ]
+          },
+          "maxItems": 4096,
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "const": "sequence",
+          "title": "Kind",
+          "type": "string"
+        },
+        "max_items": {
+          "default": 4096,
+          "maximum": 4096,
+          "minimum": 0,
+          "title": "Max Items",
+          "type": "integer"
+        },
+        "min_items": {
+          "default": 0,
+          "maximum": 4096,
+          "minimum": 0,
+          "title": "Min Items",
+          "type": "integer"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "items"
+      ],
+      "title": "RealizationSequenceConstraint",
+      "type": "object"
+    },
+    "RecordDomain": {
+      "additionalProperties": false,
+      "description": "Product structure: each declared field references another named domain.\n\n``extra`` controls undeclared fields: ``False`` (closed) rejects any field not\nnamed in ``fields``; ``True`` (open) admits them. Field values reference domain\nnames resolved against the envelope's ``domains`` map, keeping the structure\nacyclic and free of inline recursion.",
+      "properties": {
+        "extra": {
+          "default": false,
+          "title": "Extra",
+          "type": "boolean"
+        },
+        "fields": {
+          "additionalProperties": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minProperties": 1,
+          "propertyNames": {
+            "minLength": 1
+          },
+          "title": "Fields",
+          "type": "object"
+        },
+        "kind": {
+          "const": "record",
+          "default": "record",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fields"
+      ],
+      "title": "RecordDomain",
+      "type": "object"
+    },
+    "TypedRealizationDescriptionModel": {
+      "additionalProperties": false,
+      "description": "Versioned descriptive content, separate from its original author request.",
+      "properties": {
+        "authored_ref": {
+          "$ref": "#/$defs/ExperimentReferenceModel"
+        },
+        "coverage": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DescriptionCoverageModel"
+          },
+          "maxItems": 4096,
+          "title": "Coverage",
+          "type": "array"
+        },
+        "description_id": {
+          "minLength": 1,
+          "title": "Description Id",
+          "type": "string"
+        },
+        "description_version": {
+          "minLength": 1,
+          "title": "Description Version",
+          "type": "string"
+        },
+        "facts": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DescriptionFactModel"
+          },
+          "maxItems": 4096,
+          "title": "Facts",
+          "type": "array"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 256,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "provenance": {
+          "$ref": "#/$defs/DescriptionProvenanceModel"
+        },
+        "schema_version": {
+          "const": "realization-description/v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "semantic_profile": {
+          "minLength": 1,
+          "title": "Semantic Profile",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "description_id",
+        "description_version",
+        "semantic_profile",
+        "authored_ref",
+        "provenance"
+      ],
+      "title": "TypedRealizationDescriptionModel",
+      "type": "object"
     }
   },
   "$id": "https://openrae.github.io/rae/schemas/experiment-evidence-record-v1.json",
@@ -760,6 +2451,17 @@
         }
       ],
       "default": null
+    },
+    "typed_description": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TypedRealizationDescriptionModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
     }
   },
   "required": [
@@ -781,6 +2483,18 @@
   "title": "ExperimentEvidenceRecordModel",
   "type": "object",
   "x-raes-invariants": [
+    {
+      "description": "Typed descriptions preserve bounded supplied values, explicit knowledge, coverage and source identities; they do not carry author closure or establish capture satisfaction. Withheld evidence carries no known values. Profile owners bind to the fact scope and capture carrier; nested profile basis and evidence join fact provenance.",
+      "id": "evidence-description-nonauthoritative",
+      "inputs": [
+        {
+          "contract_id": "experiment-evidence-record-v1",
+          "instance_path": "#"
+        }
+      ],
+      "level": "error",
+      "validator": "raes_contracts.contracts.ExperimentEvidenceRecordModel.model_validate"
+    },
     {
       "description": "Evidence records must carry raw content as an artifact reference, content URI with checksum, or bounded payload summary; redacted/withheld records must disclose loss.",
       "id": "evidence-record-raw-content-present",

--- a/contracts/schemas/experiment-core/experiment-run-v1.json
+++ b/contracts/schemas/experiment-core/experiment-run-v1.json
@@ -118,6 +118,32 @@
       "title": "BindingScalarType",
       "type": "string"
     },
+    "BooleanDomain": {
+      "additionalProperties": false,
+      "description": "Booleans: both ``true``/``false``, or an exact boolean when ``value`` set.",
+      "properties": {
+        "kind": {
+          "const": "boolean",
+          "default": "boolean",
+          "title": "Kind",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value"
+        }
+      },
+      "title": "BooleanDomain",
+      "type": "object"
+    },
     "ClockDeclarationModel": {
       "additionalProperties": false,
       "properties": {
@@ -195,6 +221,327 @@
         "description"
       ],
       "title": "ClockDeclarationModel",
+      "type": "object"
+    },
+    "DescriptionCoverageModel": {
+      "additionalProperties": false,
+      "description": "Enumeration coverage in a named universe; never author collection closure.",
+      "properties": {
+        "fact_ids": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 4096,
+          "title": "Fact Ids",
+          "type": "array"
+        },
+        "kind": {
+          "enum": [
+            "field",
+            "collection"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 256,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "profile": {
+          "minLength": 1,
+          "title": "Profile",
+          "type": "string"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DescriptionProvenanceModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "recursive": {
+          "default": false,
+          "title": "Recursive",
+          "type": "boolean"
+        },
+        "status": {
+          "enum": [
+            "partial",
+            "complete",
+            "not-observed",
+            "withheld"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "subject": {
+          "maxLength": 4096,
+          "pattern": "^(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Subject",
+          "type": "string"
+        },
+        "universe": {
+          "minLength": 1,
+          "title": "Universe",
+          "type": "string"
+        }
+      },
+      "required": [
+        "subject",
+        "kind",
+        "universe",
+        "profile",
+        "status"
+      ],
+      "title": "DescriptionCoverageModel",
+      "type": "object"
+    },
+    "DescriptionFactModel": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "else": {
+            "properties": {
+              "profile_bindings": {
+                "maxItems": 0
+              },
+              "value": {
+                "type": "null"
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "state": {
+                "const": "known"
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "value"
+            ]
+          }
+        }
+      ],
+      "description": "One assertion; different sources at the same subject remain separate facts.",
+      "properties": {
+        "component_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Component Ref"
+        },
+        "fact_id": {
+          "minLength": 1,
+          "title": "Fact Id",
+          "type": "string"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 256,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "profile_bindings": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DomainProfileBindingModel"
+          },
+          "maxItems": 256,
+          "title": "Profile Bindings",
+          "type": "array"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DescriptionProvenanceModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "state": {
+          "enum": [
+            "known",
+            "not-observed",
+            "known-absent",
+            "withheld",
+            "contradictory",
+            "not-applicable"
+          ],
+          "title": "State",
+          "type": "string"
+        },
+        "subject": {
+          "maxLength": 4096,
+          "pattern": "^(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Subject",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "all-of": "#/$defs/RealizationAllOf",
+                  "definition-reference": "#/$defs/RealizationDefinitionReference",
+                  "delegated": "#/$defs/RealizationDelegatedValue",
+                  "domain": "#/$defs/RealizationDomainValue",
+                  "graph-reference": "#/$defs/RealizationGraphReference",
+                  "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+                  "knowledge": "#/$defs/RealizationKnowledgeValue",
+                  "literal": "#/$defs/RealizationLiteral",
+                  "recursive-record": "#/$defs/RealizationRecordConstraint",
+                  "sequence": "#/$defs/RealizationSequenceConstraint"
+                },
+                "propertyName": "kind"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/RealizationLiteral"
+                },
+                {
+                  "$ref": "#/$defs/RealizationKnowledgeValue"
+                },
+                {
+                  "$ref": "#/$defs/RealizationDelegatedValue"
+                },
+                {
+                  "$ref": "#/$defs/RealizationDomainValue"
+                },
+                {
+                  "$ref": "#/$defs/RealizationRecordConstraint"
+                },
+                {
+                  "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+                },
+                {
+                  "$ref": "#/$defs/RealizationSequenceConstraint"
+                },
+                {
+                  "$ref": "#/$defs/RealizationDefinitionReference"
+                },
+                {
+                  "$ref": "#/$defs/RealizationGraphReference"
+                },
+                {
+                  "$ref": "#/$defs/RealizationAllOf"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value"
+        }
+      },
+      "required": [
+        "fact_id",
+        "subject",
+        "state"
+      ],
+      "title": "DescriptionFactModel",
+      "type": "object"
+    },
+    "DescriptionProvenanceModel": {
+      "additionalProperties": false,
+      "description": "Actual source and basis, inherited unless a fact explicitly overrides it.",
+      "properties": {
+        "basis": {
+          "$ref": "#/$defs/ObservationBasis"
+        },
+        "configuration_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ExperimentReferenceModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "evidence_refs": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ExperimentReferenceModel"
+          },
+          "maxItems": 256,
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "observer_ref": {
+          "$ref": "#/$defs/ExperimentReferenceModel"
+        },
+        "operation_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ExperimentReferenceModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "recorded_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Recorded At",
+          "type": "string"
+        },
+        "window_ref": {
+          "minLength": 1,
+          "title": "Window Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "observer_ref",
+        "recorded_at",
+        "basis",
+        "window_ref"
+      ],
+      "title": "DescriptionProvenanceModel",
       "type": "object"
     },
     "DifficultyActionModel": {
@@ -1104,6 +1451,308 @@
         "priority"
       ],
       "title": "DifficultyThresholdRuleModel",
+      "type": "object"
+    },
+    "DomainProfileBindingBasis": {
+      "enum": [
+        "author-supplied",
+        "backend-selected",
+        "observed"
+      ],
+      "title": "DomainProfileBindingBasis",
+      "type": "string"
+    },
+    "DomainProfileBindingModel": {
+      "additionalProperties": false,
+      "description": "Typed profile data attached to one explicit host owner.",
+      "properties": {
+        "binding_id": {
+          "maxLength": 128,
+          "pattern": "^[a-z][a-z0-9]*(?:[-.][a-z0-9]+)*$",
+          "title": "Binding Id",
+          "type": "string"
+        },
+        "children": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DomainProfileBindingModel"
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "coordinate": {
+          "$ref": "#/$defs/DomainProfileCoordinateModel"
+        },
+        "owner": {
+          "$ref": "#/$defs/DomainProfileBindingOwnerModel"
+        },
+        "provenance": {
+          "$ref": "#/$defs/DomainProfileBindingProvenanceModel"
+        },
+        "schema_version": {
+          "const": "domain-profile-binding/v1",
+          "default": "domain-profile-binding/v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        }
+      },
+      "required": [
+        "binding_id",
+        "coordinate",
+        "owner",
+        "value",
+        "provenance"
+      ],
+      "title": "DomainProfileBindingModel",
+      "type": "object"
+    },
+    "DomainProfileBindingOwnerModel": {
+      "additionalProperties": false,
+      "description": "Explicit core owner, phase, context, and use for profile data.",
+      "properties": {
+        "canonical_address": {
+          "maxLength": 4096,
+          "pattern": "^#(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Canonical Address",
+          "type": "string"
+        },
+        "concept_family": {
+          "minLength": 1,
+          "title": "Concept Family",
+          "type": "string"
+        },
+        "context": {
+          "minLength": 1,
+          "title": "Context",
+          "type": "string"
+        },
+        "lifecycle_phase": {
+          "minLength": 1,
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
+        "owning_contract_id": {
+          "minLength": 1,
+          "title": "Owning Contract Id",
+          "type": "string"
+        },
+        "use": {
+          "$ref": "#/$defs/DomainProfileBindingUse"
+        }
+      },
+      "required": [
+        "owning_contract_id",
+        "canonical_address",
+        "concept_family",
+        "lifecycle_phase",
+        "context",
+        "use"
+      ],
+      "title": "DomainProfileBindingOwnerModel",
+      "type": "object"
+    },
+    "DomainProfileBindingProvenanceModel": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "basis": {
+                "const": "observed"
+              }
+            },
+            "required": [
+              "basis"
+            ]
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 1
+              }
+            },
+            "required": [
+              "evidence_refs"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "basis": {
+                "enum": [
+                  "author-supplied",
+                  "backend-selected"
+                ]
+              }
+            },
+            "required": [
+              "basis"
+            ]
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ],
+      "description": "Basis of a bound value, separate from definition trust provenance.",
+      "properties": {
+        "basis": {
+          "$ref": "#/$defs/DomainProfileBindingBasis"
+        },
+        "evidence_refs": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "source_ref": {
+          "minLength": 1,
+          "title": "Source Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "basis",
+        "source_ref"
+      ],
+      "title": "DomainProfileBindingProvenanceModel",
+      "type": "object"
+    },
+    "DomainProfileBindingUse": {
+      "enum": [
+        "constraint",
+        "typed-report",
+        "annotation",
+        "opaque-exchange"
+      ],
+      "title": "DomainProfileBindingUse",
+      "type": "string"
+    },
+    "DomainProfileCoordinateModel": {
+      "additionalProperties": false,
+      "description": "Exact immutable definition coordinate.",
+      "properties": {
+        "authority": {
+          "minLength": 1,
+          "title": "Authority",
+          "type": "string"
+        },
+        "definition_digest": {
+          "minLength": 1,
+          "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+          "title": "Definition Digest",
+          "type": "string"
+        },
+        "namespace": {
+          "maxLength": 253,
+          "pattern": "^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$",
+          "title": "Namespace",
+          "type": "string"
+        },
+        "profile_id": {
+          "maxLength": 128,
+          "pattern": "^[a-z][a-z0-9]*(?:[-.][a-z0-9]+)*$",
+          "title": "Profile Id",
+          "type": "string"
+        },
+        "revision": {
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$",
+          "title": "Revision",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "authority",
+        "profile_id",
+        "revision",
+        "definition_digest"
+      ],
+      "title": "DomainProfileCoordinateModel",
+      "type": "object"
+    },
+    "EnumDomain": {
+      "additionalProperties": false,
+      "description": "A finite value set: values equal to one listed member.",
+      "properties": {
+        "kind": {
+          "const": "enum",
+          "default": "enum",
+          "title": "Kind",
+          "type": "string"
+        },
+        "values": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "minItems": 1,
+          "title": "Values",
+          "type": "array"
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "title": "EnumDomain",
+      "type": "object"
+    },
+    "ExactDomain": {
+      "additionalProperties": false,
+      "description": "A singleton value set: values equal to ``value``.",
+      "properties": {
+        "kind": {
+          "const": "exact",
+          "default": "exact",
+          "title": "Kind",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "title": "Value"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "title": "ExactDomain",
       "type": "object"
     },
     "ExactRatioModel": {
@@ -2771,6 +3420,17 @@
           ],
           "default": null,
           "title": "Realized Value Summary"
+        },
+        "typed_description": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TypedRealizationDescriptionModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
@@ -2794,6 +3454,18 @@
           ],
           "level": "error",
           "validator": "raes_contracts.contracts.ExperimentRealizedFormDisclosureModel._validate_realized_form_disclosure"
+        },
+        {
+          "description": "Typed descriptions preserve explicit knowledge, bounded recursive values and coverage separately from author authority, with versioned sources and exact extension coordinates. Profile owners bind to the fact scope and realization-description carrier; nested profile basis and evidence join fact provenance.",
+          "id": "realized-description-nonauthoritative",
+          "inputs": [
+            {
+              "contract_id": "experiment-run-v1",
+              "instance_path": "#/realized_form_disclosures"
+            }
+          ],
+          "level": "error",
+          "validator": "raes_contracts.contracts.ExperimentRealizedFormDisclosureModel.model_validate"
         }
       ]
     },
@@ -3367,6 +4039,39 @@
       "title": "GovernedRandomOutcomeRefModel",
       "type": "object"
     },
+    "GovernedReferenceDomain": {
+      "additionalProperties": false,
+      "description": "References in a finite governed set under a named authority.",
+      "properties": {
+        "allowed_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Allowed Refs",
+          "type": "array"
+        },
+        "authority": {
+          "minLength": 1,
+          "title": "Authority",
+          "type": "string"
+        },
+        "kind": {
+          "const": "governed-reference",
+          "default": "governed-reference",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "allowed_refs"
+      ],
+      "title": "GovernedReferenceDomain",
+      "type": "object"
+    },
+    "JsonValue": {},
     "LiteralBindingValueModel": {
       "additionalProperties": false,
       "description": "Portable literal value; strict type validation occurs at its descriptor.",
@@ -3403,6 +4108,80 @@
       ],
       "title": "LiteralBindingValueModel",
       "type": "object"
+    },
+    "NullDomain": {
+      "additionalProperties": false,
+      "description": "The singleton JSON-null domain, distinct from omission or unknown.",
+      "properties": {
+        "kind": {
+          "const": "null",
+          "default": "null",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "title": "NullDomain",
+      "type": "object"
+    },
+    "NumericIntervalDomain": {
+      "additionalProperties": false,
+      "description": "Numbers of ``numeric_type`` inside a bounded interval.\n\nBoth endpoints are required (the fragment admits only *bounded* intervals,\n``envelope-semantics.md`` R3). An integer interval requires integral\nendpoints. Empty intervals are rejected at construction.",
+      "properties": {
+        "kind": {
+          "const": "numeric-interval",
+          "default": "numeric-interval",
+          "title": "Kind",
+          "type": "string"
+        },
+        "lower": {
+          "title": "Lower",
+          "type": "number"
+        },
+        "lower_closed": {
+          "default": true,
+          "title": "Lower Closed",
+          "type": "boolean"
+        },
+        "numeric_type": {
+          "$ref": "#/$defs/NumericType"
+        },
+        "upper": {
+          "title": "Upper",
+          "type": "number"
+        },
+        "upper_closed": {
+          "default": true,
+          "title": "Upper Closed",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "numeric_type",
+        "lower",
+        "upper"
+      ],
+      "title": "NumericIntervalDomain",
+      "type": "object"
+    },
+    "NumericType": {
+      "description": "Declared numeric type for a numeric-interval domain.",
+      "enum": [
+        "integer",
+        "number"
+      ],
+      "title": "NumericType",
+      "type": "string"
+    },
+    "ObservationBasis": {
+      "description": "Truthful basis requested for a reportable value.",
+      "enum": [
+        "backend-selected",
+        "observed",
+        "independently-verified",
+        "operational"
+      ],
+      "title": "ObservationBasis",
+      "type": "string"
     },
     "ParticipantExposurePolicyModel": {
       "additionalProperties": false,
@@ -3968,6 +4747,837 @@
       "title": "RandomStreamProfileReferenceModel",
       "type": "object"
     },
+    "RealizationAllOf": {
+      "additionalProperties": false,
+      "description": "A canonical conjunction used when constraints cannot be safely folded.",
+      "properties": {
+        "constraints": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "all-of": "#/$defs/RealizationAllOf",
+                "definition-reference": "#/$defs/RealizationDefinitionReference",
+                "delegated": "#/$defs/RealizationDelegatedValue",
+                "domain": "#/$defs/RealizationDomainValue",
+                "graph-reference": "#/$defs/RealizationGraphReference",
+                "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+                "knowledge": "#/$defs/RealizationKnowledgeValue",
+                "literal": "#/$defs/RealizationLiteral",
+                "recursive-record": "#/$defs/RealizationRecordConstraint",
+                "sequence": "#/$defs/RealizationSequenceConstraint"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RealizationLiteral"
+              },
+              {
+                "$ref": "#/$defs/RealizationKnowledgeValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDelegatedValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDomainValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationRecordConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationSequenceConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationDefinitionReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationGraphReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationAllOf"
+              }
+            ]
+          },
+          "maxItems": 256,
+          "minItems": 2,
+          "title": "Constraints",
+          "type": "array"
+        },
+        "kind": {
+          "const": "all-of",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "constraints"
+      ],
+      "title": "RealizationAllOf",
+      "type": "object"
+    },
+    "RealizationClosure": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "posture": {
+                "enum": [
+                  "open",
+                  "closed"
+                ]
+              }
+            },
+            "required": [
+              "posture"
+            ]
+          },
+          "then": {
+            "required": [
+              "universe",
+              "profile"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "posture": {
+                "const": "undefined"
+              }
+            },
+            "required": [
+              "posture"
+            ]
+          },
+          "then": {
+            "properties": {
+              "profile": {
+                "type": "null"
+              },
+              "universe": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ],
+      "description": "One local posture in an explicitly named semantic universe.",
+      "properties": {
+        "posture": {
+          "$ref": "#/$defs/RealizationClosurePosture",
+          "default": "undefined"
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Profile"
+        },
+        "universe": {
+          "anyOf": [
+            {
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Universe"
+        }
+      },
+      "title": "RealizationClosure",
+      "type": "object"
+    },
+    "RealizationClosurePosture": {
+      "description": "Local collection or record posture before lexical inheritance.",
+      "enum": [
+        "open",
+        "closed",
+        "undefined"
+      ],
+      "title": "RealizationClosurePosture",
+      "type": "string"
+    },
+    "RealizationCollectionMember": {
+      "additionalProperties": false,
+      "description": "One semantic member identity and its recursive constraint.",
+      "properties": {
+        "constraint": {
+          "discriminator": {
+            "mapping": {
+              "all-of": "#/$defs/RealizationAllOf",
+              "definition-reference": "#/$defs/RealizationDefinitionReference",
+              "delegated": "#/$defs/RealizationDelegatedValue",
+              "domain": "#/$defs/RealizationDomainValue",
+              "graph-reference": "#/$defs/RealizationGraphReference",
+              "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+              "knowledge": "#/$defs/RealizationKnowledgeValue",
+              "literal": "#/$defs/RealizationLiteral",
+              "recursive-record": "#/$defs/RealizationRecordConstraint",
+              "sequence": "#/$defs/RealizationSequenceConstraint"
+            },
+            "propertyName": "kind"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/RealizationLiteral"
+            },
+            {
+              "$ref": "#/$defs/RealizationKnowledgeValue"
+            },
+            {
+              "$ref": "#/$defs/RealizationDelegatedValue"
+            },
+            {
+              "$ref": "#/$defs/RealizationDomainValue"
+            },
+            {
+              "$ref": "#/$defs/RealizationRecordConstraint"
+            },
+            {
+              "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+            },
+            {
+              "$ref": "#/$defs/RealizationSequenceConstraint"
+            },
+            {
+              "$ref": "#/$defs/RealizationDefinitionReference"
+            },
+            {
+              "$ref": "#/$defs/RealizationGraphReference"
+            },
+            {
+              "$ref": "#/$defs/RealizationAllOf"
+            }
+          ],
+          "title": "Constraint"
+        },
+        "identity": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Identity",
+          "type": "array"
+        }
+      },
+      "required": [
+        "identity",
+        "constraint"
+      ],
+      "title": "RealizationCollectionMember",
+      "type": "object"
+    },
+    "RealizationDefinitionReference": {
+      "additionalProperties": false,
+      "description": "A bounded acyclic reference to another constraint definition.",
+      "properties": {
+        "kind": {
+          "const": "definition-reference",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        },
+        "target": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Target",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "target"
+      ],
+      "title": "RealizationDefinitionReference",
+      "type": "object"
+    },
+    "RealizationDelegatedValue": {
+      "additionalProperties": false,
+      "description": "A deliberately backend-selected value, distinct from unknown knowledge.",
+      "properties": {
+        "kind": {
+          "const": "delegated",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "title": "RealizationDelegatedValue",
+      "type": "object"
+    },
+    "RealizationDomainValue": {
+      "additionalProperties": false,
+      "description": "A scalar restricted by the shared bounded-domain algebra.",
+      "properties": {
+        "domain": {
+          "discriminator": {
+            "mapping": {
+              "boolean": "#/$defs/BooleanDomain",
+              "enum": "#/$defs/EnumDomain",
+              "exact": "#/$defs/ExactDomain",
+              "governed-reference": "#/$defs/GovernedReferenceDomain",
+              "null": "#/$defs/NullDomain",
+              "numeric-interval": "#/$defs/NumericIntervalDomain",
+              "record": "#/$defs/RecordDomain"
+            },
+            "propertyName": "kind"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ExactDomain"
+            },
+            {
+              "$ref": "#/$defs/EnumDomain"
+            },
+            {
+              "$ref": "#/$defs/BooleanDomain"
+            },
+            {
+              "$ref": "#/$defs/NullDomain"
+            },
+            {
+              "$ref": "#/$defs/NumericIntervalDomain"
+            },
+            {
+              "$ref": "#/$defs/GovernedReferenceDomain"
+            },
+            {
+              "$ref": "#/$defs/RecordDomain"
+            }
+          ],
+          "title": "Domain"
+        },
+        "kind": {
+          "const": "domain",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "domain"
+      ],
+      "title": "RealizationDomainValue",
+      "type": "object"
+    },
+    "RealizationGraphReference": {
+      "additionalProperties": false,
+      "description": "A graph identity edge; it is compared, never recursively expanded.",
+      "properties": {
+        "cycle_policy": {
+          "enum": [
+            "allow",
+            "forbid"
+          ],
+          "title": "Cycle Policy",
+          "type": "string"
+        },
+        "domain": {
+          "$ref": "#/$defs/GovernedReferenceDomain"
+        },
+        "kind": {
+          "const": "graph-reference",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "domain",
+        "cycle_policy"
+      ],
+      "title": "RealizationGraphReference",
+      "type": "object"
+    },
+    "RealizationIdentityAlias": {
+      "additionalProperties": false,
+      "description": "One explicit alternate identity mapped to a canonical member identity.",
+      "properties": {
+        "identity": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Identity",
+          "type": "array"
+        },
+        "target": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Target",
+          "type": "array"
+        }
+      },
+      "required": [
+        "identity",
+        "target"
+      ],
+      "title": "RealizationIdentityAlias",
+      "type": "object"
+    },
+    "RealizationKeyedCollectionConstraint": {
+      "additionalProperties": false,
+      "description": "A set-like collection matched by profile-owned semantic identity.",
+      "properties": {
+        "aliases": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RealizationIdentityAlias"
+          },
+          "maxItems": 4096,
+          "title": "Aliases",
+          "type": "array"
+        },
+        "closure": {
+          "$ref": "#/$defs/RealizationClosure",
+          "default": {
+            "posture": "undefined",
+            "profile": null,
+            "universe": null
+          }
+        },
+        "collection_kind": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Collection Kind",
+          "type": "string"
+        },
+        "identity_fields": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Identity Fields",
+          "type": "array"
+        },
+        "kind": {
+          "const": "keyed-collection",
+          "title": "Kind",
+          "type": "string"
+        },
+        "max_items": {
+          "default": 4096,
+          "maximum": 4096,
+          "minimum": 0,
+          "title": "Max Items",
+          "type": "integer"
+        },
+        "members": {
+          "items": {
+            "$ref": "#/$defs/RealizationCollectionMember"
+          },
+          "maxItems": 4096,
+          "title": "Members",
+          "type": "array"
+        },
+        "min_items": {
+          "default": 0,
+          "maximum": 4096,
+          "minimum": 0,
+          "title": "Min Items",
+          "type": "integer"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "collection_kind",
+        "identity_fields",
+        "members"
+      ],
+      "title": "RealizationKeyedCollectionConstraint",
+      "type": "object"
+    },
+    "RealizationKnowledgeValue": {
+      "additionalProperties": false,
+      "description": "A value-free knowledge state that never grants realization authority.",
+      "properties": {
+        "kind": {
+          "const": "knowledge",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        },
+        "state": {
+          "enum": [
+            "unknown",
+            "redacted",
+            "not-applicable"
+          ],
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "state"
+      ],
+      "title": "RealizationKnowledgeValue",
+      "type": "object"
+    },
+    "RealizationLiteral": {
+      "additionalProperties": false,
+      "description": "A type-sensitive exact JSON value, including explicit JSON null.",
+      "properties": {
+        "kind": {
+          "const": "literal",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Value"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "title": "RealizationLiteral",
+      "type": "object"
+    },
+    "RealizationOrigin": {
+      "description": "Authority origin retained independently of the represented value.",
+      "enum": [
+        "author",
+        "default",
+        "processor",
+        "backend",
+        "observation"
+      ],
+      "title": "RealizationOrigin",
+      "type": "string"
+    },
+    "RealizationPresence": {
+      "description": "Whether the addressed member must, may, or must not exist.",
+      "enum": [
+        "required",
+        "optional",
+        "forbidden"
+      ],
+      "title": "RealizationPresence",
+      "type": "string"
+    },
+    "RealizationRecordConstraint": {
+      "additionalProperties": false,
+      "description": "A recursive record whose closure is independent of child precision.",
+      "properties": {
+        "closure": {
+          "$ref": "#/$defs/RealizationClosure",
+          "default": {
+            "posture": "undefined",
+            "profile": null,
+            "universe": null
+          }
+        },
+        "fields": {
+          "additionalProperties": {
+            "discriminator": {
+              "mapping": {
+                "all-of": "#/$defs/RealizationAllOf",
+                "definition-reference": "#/$defs/RealizationDefinitionReference",
+                "delegated": "#/$defs/RealizationDelegatedValue",
+                "domain": "#/$defs/RealizationDomainValue",
+                "graph-reference": "#/$defs/RealizationGraphReference",
+                "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+                "knowledge": "#/$defs/RealizationKnowledgeValue",
+                "literal": "#/$defs/RealizationLiteral",
+                "recursive-record": "#/$defs/RealizationRecordConstraint",
+                "sequence": "#/$defs/RealizationSequenceConstraint"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RealizationLiteral"
+              },
+              {
+                "$ref": "#/$defs/RealizationKnowledgeValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDelegatedValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDomainValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationRecordConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationSequenceConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationDefinitionReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationGraphReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationAllOf"
+              }
+            ]
+          },
+          "maxProperties": 4096,
+          "title": "Fields",
+          "type": "object"
+        },
+        "kind": {
+          "const": "recursive-record",
+          "title": "Kind",
+          "type": "string"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "fields"
+      ],
+      "title": "RealizationRecordConstraint",
+      "type": "object"
+    },
+    "RealizationSequenceConstraint": {
+      "additionalProperties": false,
+      "description": "An ordered collection; position remains meaningful and duplicates survive.",
+      "properties": {
+        "closure": {
+          "$ref": "#/$defs/RealizationClosure",
+          "default": {
+            "posture": "undefined",
+            "profile": null,
+            "universe": null
+          }
+        },
+        "items": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "all-of": "#/$defs/RealizationAllOf",
+                "definition-reference": "#/$defs/RealizationDefinitionReference",
+                "delegated": "#/$defs/RealizationDelegatedValue",
+                "domain": "#/$defs/RealizationDomainValue",
+                "graph-reference": "#/$defs/RealizationGraphReference",
+                "keyed-collection": "#/$defs/RealizationKeyedCollectionConstraint",
+                "knowledge": "#/$defs/RealizationKnowledgeValue",
+                "literal": "#/$defs/RealizationLiteral",
+                "recursive-record": "#/$defs/RealizationRecordConstraint",
+                "sequence": "#/$defs/RealizationSequenceConstraint"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RealizationLiteral"
+              },
+              {
+                "$ref": "#/$defs/RealizationKnowledgeValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDelegatedValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationDomainValue"
+              },
+              {
+                "$ref": "#/$defs/RealizationRecordConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationKeyedCollectionConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationSequenceConstraint"
+              },
+              {
+                "$ref": "#/$defs/RealizationDefinitionReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationGraphReference"
+              },
+              {
+                "$ref": "#/$defs/RealizationAllOf"
+              }
+            ]
+          },
+          "maxItems": 4096,
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "const": "sequence",
+          "title": "Kind",
+          "type": "string"
+        },
+        "max_items": {
+          "default": 4096,
+          "maximum": 4096,
+          "minimum": 0,
+          "title": "Max Items",
+          "type": "integer"
+        },
+        "min_items": {
+          "default": 0,
+          "maximum": 4096,
+          "minimum": 0,
+          "title": "Min Items",
+          "type": "integer"
+        },
+        "origin": {
+          "$ref": "#/$defs/RealizationOrigin",
+          "default": "author"
+        },
+        "presence": {
+          "$ref": "#/$defs/RealizationPresence",
+          "default": "required"
+        }
+      },
+      "required": [
+        "kind",
+        "items"
+      ],
+      "title": "RealizationSequenceConstraint",
+      "type": "object"
+    },
     "RealizedBindingProvenanceModel": {
       "additionalProperties": false,
       "description": "Portable provenance for one binding actually realized by its owner.",
@@ -4093,6 +5703,40 @@
         "evidence_refs"
       ],
       "title": "RealizedTimeModelProvenanceModel",
+      "type": "object"
+    },
+    "RecordDomain": {
+      "additionalProperties": false,
+      "description": "Product structure: each declared field references another named domain.\n\n``extra`` controls undeclared fields: ``False`` (closed) rejects any field not\nnamed in ``fields``; ``True`` (open) admits them. Field values reference domain\nnames resolved against the envelope's ``domains`` map, keeping the structure\nacyclic and free of inline recursion.",
+      "properties": {
+        "extra": {
+          "default": false,
+          "title": "Extra",
+          "type": "boolean"
+        },
+        "fields": {
+          "additionalProperties": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minProperties": 1,
+          "propertyNames": {
+            "minLength": 1
+          },
+          "title": "Fields",
+          "type": "object"
+        },
+        "kind": {
+          "const": "record",
+          "default": "record",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fields"
+      ],
+      "title": "RecordDomain",
       "type": "object"
     },
     "ScenarioBindingTargetModel": {
@@ -5015,6 +6659,76 @@
         "terminal_attempt_id"
       ],
       "title": "TrialRunProvenanceModel",
+      "type": "object"
+    },
+    "TypedRealizationDescriptionModel": {
+      "additionalProperties": false,
+      "description": "Versioned descriptive content, separate from its original author request.",
+      "properties": {
+        "authored_ref": {
+          "$ref": "#/$defs/ExperimentReferenceModel"
+        },
+        "coverage": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DescriptionCoverageModel"
+          },
+          "maxItems": 4096,
+          "title": "Coverage",
+          "type": "array"
+        },
+        "description_id": {
+          "minLength": 1,
+          "title": "Description Id",
+          "type": "string"
+        },
+        "description_version": {
+          "minLength": 1,
+          "title": "Description Version",
+          "type": "string"
+        },
+        "facts": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DescriptionFactModel"
+          },
+          "maxItems": 4096,
+          "title": "Facts",
+          "type": "array"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 256,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "provenance": {
+          "$ref": "#/$defs/DescriptionProvenanceModel"
+        },
+        "schema_version": {
+          "const": "realization-description/v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "semantic_profile": {
+          "minLength": 1,
+          "title": "Semantic Profile",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema_version",
+        "description_id",
+        "description_version",
+        "semantic_profile",
+        "authored_ref",
+        "provenance"
+      ],
+      "title": "TypedRealizationDescriptionModel",
       "type": "object"
     },
     "ValidationBasisDisclosureModel": {

--- a/docs/decisions/issue-1209-clause-mapping.md
+++ b/docs/decisions/issue-1209-clause-mapping.md
@@ -89,3 +89,13 @@ research outcomes remain unchanged.
 | 10. Retention checks depended on `repr` formatting | Retention and redaction inspect stored scalar values structurally. |
 | 11. Coverage kind and universe cases had asymmetric assertions | Separate named tests cover wrong kind and effective universe. |
 | 12. Ownership assertions only counted failures | The test asserts each forbidden path and its ownership rule ID. |
+
+## Maintainability remediation
+
+Sonar findings are addressed by typed helpers for assertion comparison, coverage,
+projection, profile/evidence admission and promotion. Promotion decisions and
+runtime profile admission group their related inputs explicitly. These changes
+preserve the contract schemas and existing knowledge, provenance, selection and
+refinement rules. The issue regressions cover the refactored paths;
+`test_runtime_description_profiles_preserve_explicit_host_policy` additionally
+checks configured opaque-profile admission through execution and retention.

--- a/docs/decisions/issue-1209-clause-mapping.md
+++ b/docs/decisions/issue-1209-clause-mapping.md
@@ -1,0 +1,91 @@
+# Issue 1209: partial description acceptance evidence
+
+This change implements generic description interchange and conformance in RAE.
+The component values in tests are fixture data. Backend selection, probes and
+scenario recipes remain downstream, following OpenRAE/hub issue 3.
+
+| Acceptance clause | Implementation and verification |
+| --- | --- |
+| 1. Typed recursive detail in existing lifecycle envelopes, with coverage and provenance | `contracts/realization_descriptions.py` and `contracts/experiment_evidence.py`; `test_partial_description_round_trips_through_existing_evidence_envelope`, `test_collection_identity_must_match_the_supplied_member` and offline profile carriage test in `test_issue_1209_descriptions.py`. |
+| 2. Missing, absent, withheld and contradictory remain distinct; no defaults | Explicit fact states and bounded recursive values; empty-value and nonknown-state tests in `test_issue_1209_descriptions.py`; absence and conflict tests in `test_issue_1209_description_relations.py`. |
+| 3. Original intent remains immutable; comparison requires conforming projection | `description_projection.py` invokes canonical realization evaluation only with complete compatible coverage. Partial, wrong-value, complete, mixed-window and original-immutability tests in `test_issue_1209_description_relations.py`. |
+| 4. Explicit promotion of selected detail with provenance | `description_promotion.py` returns a new constraint document and existing transformation report after canonical composition/refinement; promotion selection, immutable source, conflicting and absent-ancestor tests in `test_issue_1209_description_relations.py`. |
+| 5. Partial, private, offline and conflicting interchange; unsupported relations honest | Exact profile bindings use the existing offline admission context. Opaque carriage requires explicit host policy; comparison/promotion refuse unsupported private semantics. Private offline round-trip, keyed reordering, conflict, duplicate-ingress and finite-budget tests in the description suites. |
+| 6. Capture admission and actual evidence remain mandatory | Existing #1112 admission and byte validation owners are reused. `test_typed_evidence_does_not_replace_required_emitted_bytes` in `test_issue_1209_description_lifecycle.py` and `test_issue_1112_capture_admission.py` cover this boundary. |
+| 7. Selected backend detail at requested depth | Existing describer receives selector before acquisition. `description_reporting.py` bounds and selects supplied facts; five-component, protection-restores-depth, requested-window and excluded-descendant tests exercise generic callback fixtures. |
+| 8. Collection, retention and export remain independent | Existing #1212 lifecycle owns admission/protection/persistence. Typed description retention/recovery and redaction tests in `test_issue_1209_description_lifecycle.py`; required-export and pre-mutation refusal tests in `test_issue_1212_runtime_boundaries.py`. |
+| 9. Realization detail and telemetry completeness remain independent | Existing `test_issue_1212_observation_demand.py` tests detailed realization without experimental demand and abstract exhaustive capture; new five-component fixture has backend-selected detail with zero observed evidence. No deployment normalization runs during description admission or projection. |
+| 10. Refinement, provenance and conditional augmentation remain governed | Canonical realization relation/composition and `ArtifactTransformationReportModel` retain the ADR-064/066 and #341/#342 authority boundary. Existing run augmentation validation is unchanged. Promotion records original/source/target digests and explicit actor, decision and time. |
+
+Production paths above are relative to
+`implementations/python/packages/raes_contracts/`; test paths are relative to
+`implementations/python/tests/`. Runtime carriage uses the existing
+`raes_runtime/observation_execution.py` and `observation_results.py` owners.
+The published evidence/run schemas and their publication entries accompany
+reference model changes; valid partial and invalid withheld-value fixtures
+exercise the existing experiment evidence contract.
+
+SEM-218 stays ACTIVE. Its existing exact-authority implementation remains in
+place; this diff adds descriptive evidence and explicit promotion without
+turning coverage, backend choice or schema validity into author authority.
+
+Verification also replays fresh specification-coverage 8.0.0 and formal
+semantic-validation 10.0.0 captures. These bind the new implementation digest
+while retaining every previous capture and the preregistered outcome and
+missing-concept denominators. The supported-release checks advance with the
+new immutable records; they still reject unsupported future revisions.
+
+## First review remediation
+
+All six findings in the [review record](https://github.com/OpenRAE/rae/issues/1209#issuecomment-5648017546)
+are addressed in the local delivery diff. Coverage consumers were swept across
+report projection, exhaustive demand and authored assessment; profile owners
+were swept across both lifecycle carriers and every nested binding.
+
+| Finding | Regression evidence |
+| --- | --- |
+| Numeric type erased in conflict markers | `test_literal_conflicts_preserve_integer_versus_float_type` in `test_issue_1209_description_review.py` |
+| Coverage not bound to the boundary it satisfies | `test_required_exhaustive_description_rejects_unmatched_coverage`, `test_conformance_requires_root_effective_coverage_universe` and `test_conformance_rejects_coverage_of_wrong_kind`, `test_narrow_report_does_not_retain_a_broader_complete_claim`, `test_selector_exclusions_remove_complete_coverage_claims`, and `test_coverage_cannot_claim_stronger_basis_than_the_report` in the same file |
+| Mixed windows hide a known author violation | `test_mixed_windows_do_not_hide_a_known_author_violation` in the same file |
+| Profile owner escapes the selected fact or lifecycle carrier | `test_profile_owners_are_bound_to_fact_and_lifecycle_carrier` in `test_issue_1209_description_profiles.py`, including both carriers and nested owners |
+| Protection changes carrier to escape projection | `test_protector_cannot_escape_typed_projection_by_changing_carrier` in `test_issue_1209_description_review.py` |
+| Nested profile basis or evidence is forged | `test_backend_selected_fact_cannot_forge_observed_profile_basis` and `test_profile_evidence_must_join_the_externally_verified_reference` in `test_issue_1209_description_profiles.py` |
+
+## Second review remediation
+
+Both findings in the [second review record](https://github.com/OpenRAE/rae/issues/1209#issuecomment-5648736094)
+are addressed. Evidence verification resolves provenance per retained fact and
+coverage claim, then uses the existing complete experiment-reference key to
+compare against the reporting API's unqualified evidence-record identity. The
+class sweep includes inherited and overridden provenance, nested profile IDs,
+both projection passes around protection, and the existing runtime disclosure
+writer, which already interprets the outer identifier as an evidence-record ID.
+
+`test_projection_checks_effective_evidence_provenance` and
+`test_inherited_provenance_still_requires_verified_reference` in
+`test_issue_1209_description_evidence.py` pin override semantics.
+`test_reporting_rejects_unverified_reference_qualifiers` in the same file
+rejects forged kind, version, digest, path and differently qualified duplicate
+IDs at each reporting boundary, including nested profiles and protection.
+The new cases reproduced both defects before the fix and pass after it.
+
+## Test-quality review remediation
+
+The [test-quality findings](https://github.com/OpenRAE/rae/issues/1209#issuecomment-5648929880)
+are addressed with test changes. Existing production validators and recorded
+research outcomes remain unchanged.
+
+| Finding | Regression evidence or test repair |
+| --- | --- |
+| 1. Nested profile forgery was masked by a fact-level forgery | `test_nested_profile_reference_cannot_escape_verified_fact` exercises admission and protection; `test_nested_profile_evidence_is_checked_independently_by_report_join` isolates the nested evidence join. |
+| 2. Coverage arithmetic reused its own generated result as oracle | `test_analysis_arithmetic_has_an_independent_mixed_classification_oracle` and `test_noncritical_evidence_status_is_derived_independently` use hand-authored counts and outcomes. |
+| 3. Evidence-validator rules lacked negative cases | The specification-coverage integrity table and formal-semantic-validation review suite exercise the previously unasserted rules. Exception tests cover both retained replay versions and both production replay modes. |
+| 4. Coverage tests depended exclusively on committed research data | `test_specification_coverage_units.py` supplies independent arithmetic, source, request and execution-error fixtures. |
+| 5. Shared rule IDs hid which check failed | Production-tamper assertions name the exact message and snapshot path; dedicated tests cover missing command selection, extra selected artifacts, and the retest commit pin. |
+| 6. Production tampering covered only satisfiability | All four tamper tests now cover satisfiability and exploit-path evidence. |
+| 7. Participant-trust test invoked unrelated release replay | The test directly exercises `_participant_replay_failures` with a minimal release and controlled runner. |
+| 8. Promotion assertions matched unrelated guard messages | Each promotion rejection now names its intended complete guard message. |
+| 9. Repeated evidence loads lacked explicit isolation | Cached committed loads return deep copies; `test_cached_evidence_is_loaded_once_and_copied_per_test` pins isolation. Loader-specific tests retain real loader calls. |
+| 10. Retention checks depended on `repr` formatting | Retention and redaction inspect stored scalar values structurally. |
+| 11. Coverage kind and universe cases had asymmetric assertions | Separate named tests cover wrong kind and effective universe. |
+| 12. Ownership assertions only counted failures | The test asserts each forbidden path and its ownership rule ID. |

--- a/docs/decisions/issue-1209-partial-capture-descriptions-preflight.md
+++ b/docs/decisions/issue-1209-partial-capture-descriptions-preflight.md
@@ -1,0 +1,207 @@
+# Issue 1209 partial realization reports and capture preflight
+
+Status: non-normative architecture guidance. Requirement: SEM-218.
+Inspected baseline: `c8996122`, branch `1209-partial-capture-descriptions`.
+
+Issue #1209 extends descriptive fidelity in existing lifecycle envelopes. It
+does not redefine author authority or introduce another evidence system.
+[ADR-105](adrs/adr-105-recursive-partial-description-semantics.md),
+[ADR-064](adrs/adr-064-experiment-evidence-and-measure-contract-boundary.md),
+[ADR-066](adrs/adr-066-observability-evidence-plane-separation.md), and the
+[governing design intent](../research/language-extensibility/design-intent.md)
+already decide the architecture; no new ADR is needed. This note locks down the
+remaining integration boundaries, not an implementation sequence or public syntax.
+
+## Findings that determine the design
+
+Paths below are relative to `implementations/python/packages/` unless stated
+otherwise.
+
+- `raes_processor/semantics/realization_concern_observations.py` validates
+  observations with SDL adapters, restores protected values as blanks for shape
+  checking, then dumps normalized models. This can introduce authoring defaults
+  and completeness requirements into reports. Its `typed_runtime_observation_shape`
+  helper also serves `planner/realization_preparation.py`,
+  `prepared_node_admission.py`, and `prepared_node_semantics.py`. Globally relaxing
+  that helper would weaken preparation admission, not just improve capture.
+- `raes_contracts.realization_structure` already owns bounded recursive values,
+  domains, references, stable collection identity, local closure, composition,
+  refinement, and diagnostic-bearing relation outcomes. Its concrete-value
+  evaluator treats a missing required dictionary member as absent/nonconformant.
+  A partial capture cannot be passed to it as an ordinary complete dictionary.
+  `RealizationKnowledgeValue` is not a complete report-coverage contract, and
+  `RealizationPresence.FORBIDDEN` is an obligation, not an observation of absence.
+- `raes_contracts/observation_reporting.py` already separates achieved basis from
+  requested basis and protects selected descriptions. However,
+  `raes_runtime/observation_results.py` embeds JSON in
+  `ExperimentRealizedFormDisclosureModel.realized_value_summary` (bounded to
+  16 KiB at that producer). The envelope has source/basis/evidence references,
+  but this string is not a portable typed recursive report with coverage.
+- `RuntimeSnapshot` requires unique concern disclosures. Its observation DTOs
+  and store codecs are intentionally restrictive and mostly value-free, with
+  governed substrate/OS exceptions. Conflicting observations must not be forced
+  into one unique concern slot, overwritten, or smuggled through `metadata`.
+- #1212 is present: normalized demand, selector capability resolution,
+  description callbacks, lifecycle protection, and retention-aware operation
+  results already exist. Built-in selection reporting currently describes bound
+  compute substrate; it is not a general Linux/Kali/software inventory reporter.
+  `observation_admission.py` rejects requested export and mandatory observation
+  combined with mutation until their execution owners exist. Richer DTOs alone
+  do not make either operation safe or supported.
+
+## Representation and authority guardrails
+
+Use the shared recursive structural vocabulary through its public contracts
+owner. Extend existing report/evidence envelopes with the smallest versioned
+descriptive carrier needed for coverage and provenance; do not clone every SDL
+type into an observation model or create a parallel recursive relation engine.
+Keep report validation distinct from authoring and prepared-resource admission.
+Reuse identity/domain/security rules for supplied fields without filling missing
+fields from deployment defaults, interpreting report coverage as author closure,
+or assigning authority merely because a node has `origin="observation"`.
+
+The report must preserve these independent dimensions at the scope where they
+apply, including inherited metadata and explicit per-field overrides:
+
+Metadata overrides cannot weaken applicable marking or lifecycle prohibitions.
+
+| Dimension | Required meaning |
+| --- | --- |
+| Value and identity | Typed core or extension value, canonical semantic address, collection profile/revision, and exact extension identity. Unknown extension identity is not `other`. |
+| Knowledge | Not observed, positively known absent, withheld/redacted, not applicable, and known value remain distinguishable. `null`, empty string, false, zero and empty collection are values, not generic absence markers. |
+| Coverage | Named field/collection universe, observed subset, completeness/limitations and applicable window. Missing outside covered scope means unobserved; absence requires explicit evidence/basis covering that subject. |
+| Basis and provenance | Observer/selector identity and version, observation time/window, backend-selected versus observed/independently verified basis, and applicable run/operation/configuration/profile bindings. Reuse existing reference and RFC 3339 time contracts. |
+| Conflict | Preserve incompatible assertions and their individual sources/times. Reconcile only under explicit comparable scope/window rules; different-time changes are not automatically contradictions, and latest arrival does not establish truth. |
+| Policy and authority | Purpose, marking, collection/retention/export policy, and original author constraints remain separate from the reported facts. |
+
+Malformed duplicate keys or ambiguous collection identities are invalid syntax;
+multiple legitimate assertions about one identity are report history/conflict.
+Keyed inventory uses semantic keys, ordered sequences retain order, and partial
+enumeration/pagination cannot establish collection completeness. Bounds, loss,
+withholding, or a failed collector must never be rendered as an empty complete
+inventory. Do not infer “no other machine files/packages exist” from closure of a
+named portable inventory.
+
+Comparison needs an explicit coverage-aware projection into the existing
+recursive relation. Preserve its `conformant`, `nonconformant`, `unresolved`,
+`invalid`, `unsupported`, and `limit-exceeded` distinctions. Checking a supplied
+value can expose a contradiction; missing evidence cannot prove satisfaction or
+violation of an unobserved fact. A conforming observed subset does not prove a
+whole realization. Withheld values without an admitted comparison basis remain
+unresolved. A valid schema, checksum, manifest claim, or nonempty report does not
+prove delivery or independent verification. Preserve #1204 result admission and
+its trusted predecessor when a backend claims an invalid successful result.
+
+Private/offline descriptions use `raes_contracts.domain_profiles`: pinned
+namespace/name/revision/content identity, bounded inert schema parsing, offline
+resolution, and operation-specific semantic support. Preserve bounded unknown
+extension content only under the admitted opaque/nonbinding exchange rules;
+report unsupported comparison honestly. Required execution or promotion semantics
+cannot use that fallback. Do not fetch profiles, load handlers from data, require
+profiles for unreported internal backend choices, or promote private recipes into
+core catalogs. A digest establishes identity/integrity, not trust or truth.
+
+## Promotion and refinement boundary
+
+Promotion is an explicit selection of captured facts into a **new authored
+artifact**. Preserve the original request and capture unchanged. Record source
+artifact identity/version/digest, selected semantic paths and facts, actor or
+decision identity, time, target artifact identity, and transformation limitations
+through existing artifact references and provenance owners. Reuse
+`raes_contracts/contracts/artifact_transformations.py` identity/preservation/loss reporting and
+SDL phase provenance where applicable; neither currently constitutes a complete
+promotion operation. Do not use the intellectual-lineage ledger as run provenance.
+
+Only selected, admissible facts gain authority. Unknown, withheld, conflicting,
+or semantically unsupported assertions cannot silently become exact constraints;
+resolving a conflict or supplying a value is a separately recorded author decision.
+Never promote restored blanks, comparison aliases, default-inserted placeholders,
+credentials, or unselected incidental descendants. An actual backend-selected
+value can be deliberately promoted with its selection basis preserved. Selecting
+one child does not close siblings or a
+collection. A deliberate closure promotion requires its own named universe and
+adequate coverage. Revalidate the new artifact through normal SDL/semantic gates.
+
+Call the result a refinement only if the existing composition/refinement relation
+establishes that it preserves the base constraints. A selected contradictory fact
+does not authorize weakening an exact declaration. A changed author decision is a
+new revision, not a conforming refinement or retroactive successful realization.
+#341 retains task/run/study refinement via `validate_experiment_run_against_task`;
+#342 retains realized-source provenance and conditional augmentation disclosure.
+
+## Canonical integration owners
+
+| Concern | Incumbents and required reuse |
+| --- | --- |
+| Recursive semantics | `raes_contracts.realization_structure`, `bounded_domains`, `domain_profiles`, and `specs/sdl/recursive-realization-constraints.md`; reuse stable addresses, limits, profile resolution, composition and explicit relation outcomes. Pure contracts must not import SDL, processor, backend, or runtime services. |
+| Runtime field ownership | `realization_concerns.py`, `realization_runtime_concern_profiles.py`, `realization_concern_projections.py`, `realization_typed_runtime_projection.py`, and `realization_snapshot_sanitization.py`; extend their owner/adaptation seams, keeping preparation validation and public safe projections intact. |
+| Author-to-execution integrity | `raes.explicitness`, `phase_contracts`, compiler realization owners, `planner/realization_authority.py`, runtime preparation/authority/result admission; reporting cannot alter admitted author constraints, envelope/configuration binding, or execution success. |
+| Demand and callbacks | `observation_demand`, scope/resolution/validation helpers, `observation_reporting`, `observation_lifecycle`, runtime `observation_capabilities`, `observation_admission`, `observation_execution`, `observation_native`, and `backend_observation_calls`; one demand resolver and one lifecycle, including direct-plan admission. |
+| Capture and evidence | `ObservationCaptureOffer`, `ObservationCapabilities`, `raes_processor.capture_admission.capture_admission_diagnostics`, `ExperimentCaptureSpecModel`, `ExperimentEvidenceRecordModel`, and `evidence_satisfaction.validate_experiment_run_evidence`; #1112 owns matching actual offers and evidence to required capture, including source/window/redaction/loss. Do not union unrelated offers into fictitious complete coverage. |
+| Report and claim strength | `ExperimentRealizedFormDisclosureModel`, `ValidationBasisDisclosureModel`, `ExperimentRunModel` reference checks, `raes_conformance/conformance/observability.py`, and operations evidence-run validators/artifact writers. Structured detail must survive these consumers; prose summaries are presentation, not semantic authority. |
+| Persistence and recovery | `observation_results.py`, `ControlPlaneStore`/`LocalControlPlaneStore`, snapshot and observation codecs, local revision/record codecs, and terminal operation commits; one durable representation with existing migration, revision/CAS, lease and idempotency behavior. Update typed DTO conversion in both directions, including `control_plane_api_models.py`. |
+
+## Security and whole-repository gates
+
+These are obligations on the eventual implementation, not claims established by
+this documentation review. Apply them to ingestion, comparison, promotion,
+storage/recovery and every report/export surface, not just the edited helper.
+
+| Layer | Required design behavior |
+| --- | --- |
+| Source and payload parsing | Reuse `raes.parser`, YAML mapping validation and `SDLParserLimits` when accepting authored/promoted SDL; closed `ContractModel` and versioned schema validation for reports. Bound bytes, depth, nodes, collection members, references and diagnostic work before traversal, copying, hashing or serialization. Reject nonfinite numbers and ambiguous identities; do not coerce partial records through full SDL defaults. |
+| Profile/config validation | Reuse `domain_profiles` safe schema/admission machinery and selected configuration/profile bindings. Pinned schema shape and installed semantic comparison support are different checks. Do not bypass `prepared_node_*` or `realization_preparation` completeness/capability checks to accept partial reports. |
+| Secrets and environment binding | Preserve `SecretReferenceId`, `contracts/experiment_bindings.py`'s discriminated `BindingValue` and configuration-target validation, `RuntimeEnvironmentVariable`, and existing concern-specific classification/presence/commitment projections. Reports carry no resolved operator secrets, ambient environment dump or new environment lookup. Protected blanks are validator placeholders, never facts. Commitments are not encryption and must not be newly emitted for low-entropy secrets merely to enable comparison. |
+| Trust, URI and artifact ingress | Reuse `uri_safety.validate_safe_absolute_uri`, artifact integrity/trust admission and exact profile resolution. References remain inert and credential-free; no automatic network retrieval, host path traversal, executable profile loading, or recursive archive import during report parsing. |
+| Authorization and audiences | Reuse `_ControlPlaneApiAuth`, `ControlPlaneSecurityConfig`, target/role binding, participant visibility/marking gates, and `control_plane_plan_authorization`. Read/report access is not promotion authority, backend submission is not author consent, and reportability does not authorize participant access or export. Any exposed promotion mutation needs an explicit author-authorized operation through existing mutation admission, not automatic promotion by a report receiver. |
+| Host/backend collection | Extend `ObservationRuntime` callbacks and existing reference/OCI/libvirt driver and `guest_transport` boundaries. Select permitted fields before probes or buffering; enforce deadlines and producer-side item/byte limits (post-collection tuple checks alone cannot bound acquisition). Keep command arguments fixed/validated and secrets out of argv, environment diagnostics, stdout/stderr and temporary artifacts. Pure projection/promotion starts no process. Preserve readiness, ownership, fresh binding and cleanup checks as operational inputs. |
+| Diagnostics and audit | Reuse `Diagnostic`/`DiagnosticModel`, runtime portable diagnostic sanitization, bounded control-plane audit/offload, and `_operation_routes.py` redacted 422/500 handlers. Expose stable safe codes and addresses, never raw Pydantic inputs, captured values, exception text or probe output. Bound/sanitize attacker-controlled identities too; add no exception hierarchy or logging channel. |
+| Retention and storage | Enforce #1212 independently before collection, queues/buffers, terminal payloads, snapshots, temporary files, history and backups. Reuse secure local store paths, private modes, symlink/reparse/link checks, transactions and snapshot revisions. Freeze/copy admitted nested payloads to prevent mutation after validation. Nonretained descriptions are immediate-result only; do not reacquire on polling/restart, or claim recoverability without authorized retention. |
+| Export and failure recovery | Reuse audience-safe serializers and lifecycle admission. Keep the existing unsupported-export and required-observation-plus-mutation rejections until governed delivery/compensation is integrated with the existing owners. Database atomicity is not infrastructure rollback; retry/idempotency cannot silently recollect forbidden data or repeat a promotion. A projection pass must not erase a detected realization violation. |
+| Repository publication/workflow | `.ground-control.yaml`, `.gc/plan-rules.md`, `Makefile`, `noxfile.py`, `.pre-commit-config.yaml` and canonical `tools/` checks govern changes. Published schemas under `contracts/schemas/` remain authoritative: synchronize schema publication entries/manifest, versions, generated bundle/exports, fixtures and compatibility decisions per ADR-009/061. Reuse package-boundary and generated-artifact checks; do not edit generated mirrors, release versions or changelogs by hand. Set `RAES_REQUIREMENT_UID=SEM-218`. |
+
+## Extensibility and acceptance boundaries
+
+The extension seam is a versioned, coverage-bearing description carried by the
+existing lifecycle contracts, with explicit semantic address/profile resolver,
+work limits, scope/time coverage, achieved basis and protection policy inputs.
+Backend selector-family capabilities and describe/collect callbacks supply data;
+they must not define independent coverage or authority semantics. A second private
+profile, nested collection, or abstract action trace should use those parameters
+without adding another backend-specific report schema or editing a core catalog.
+Specify lossless round-trip and negotiated revision behavior before publishing a
+changed contract. Older consumers must reject unsupported required meaning or
+disclose permitted loss, never silently flatten it to a successful summary.
+
+Acceptance must exercise the existing #1203/#1204 recursive and result-boundary,
+#985/#1078 secret/projection, #1112 capture, #1212 lifecycle, experiment-contract,
+and control-plane API/store regression families. Required evidence includes:
+
+- Partial core/private/offline captures round-trip with absent, false/null/empty,
+  withheld, unsupported and conflicting facts distinct; reordered keyed members,
+  ordered sequences, stale bindings, profile mismatches and exhausted budgets
+  preserve honest outcomes across serialization and restart.
+- Explicit siblings remain binding under open aggregates. A partial observation
+  cannot fabricate defaults or prove whole-object conformance. Selected promotion
+  preserves source artifacts and records a new authored identity and its decision.
+- Five Linux boxes and Kali/tool selections report actual bound choices at the
+  requested supported depth without fabricated independent observations; an
+  abstract model reports its own semantics without invented machine inventory.
+- Exact filesystem/image detail with no experimental data and an abstract model
+  with exhaustive supported action traces remain independent combinations.
+  Collector, store, queue, temporary-file and exporter assertions establish that
+  prohibited data was never acquired/retained, not merely omitted at response time.
+- Authorization, hostile extension payloads, secret-bearing validation failures,
+  source/window conflicts, failed capture, retry/recovery and direct submission
+  preserve existing security, capture-satisfaction and result-admission gates.
+
+Non-goals: a new authority algebra, generic inventory scanner, universal product
+catalog, mandatory backend recipe authoring, full-machine completeness, a new
+store/API/workflow stack, or implementation of all live capture/export backends.
+Do not repurpose raw evidence, derived measures, runtime metadata or summary
+strings as the missing typed contract. Do not weaken exact unsupported rejection,
+ADR-070 universal subsumption, #1204 delivery checks, #341 refinement, #342 source
+provenance, or conditional augmentation disclosures. #1212 supplies demand; #1112
+supplies capture admission; #1210 retains program-wide migration. The supplied
+issue requires native blockers to clear before dependent implementation; their
+current GitHub status was not re-fetched for this local preflight.

--- a/docs/explain/reference/partial-realization-descriptions.md
+++ b/docs/explain/reference/partial-realization-descriptions.md
@@ -17,7 +17,9 @@ The Python reference API exposes `TypedRealizationDescriptionModel` from
 `raes_contracts.description_reporting` admits bounded JSON without duplicate
 members. Private profile bindings retain exact coordinates and inert values;
 `admit_description_profiles` requires an explicit offline context and policy.
-Opaque acceptance does not enable semantic comparison.
+Opaque acceptance does not enable semantic comparison. Runtime adapters accept
+a `DescriptionProfileAdmission` pairing the offline context with its host policy
+through `ConfiguredObservationRuntime(description_profiles=...)`.
 
 `assess_realization_description` in `raes_contracts.description_projection`
 compares against the original constraint document and its digest. Known facts
@@ -28,8 +30,9 @@ different windows cannot silently become one state. Overlapping partial record
 projections require explicit reconciliation.
 
 `promote_description` in `raes_contracts.description_promotion` takes selected
-known scalar fact IDs, the original constraints, an actor, decision ID, time and
-new target identity/version. It returns a new document and transformation
+known scalar fact IDs, the original constraints, and a
+`DescriptionPromotionDecision` containing the actor, decision ID, time and new
+target identity/version. It returns a new document and transformation
 record after checked composition and refinement. It performs no authoring write
 or execution. The original document and unselected facts remain intact.
 

--- a/docs/explain/reference/partial-realization-descriptions.md
+++ b/docs/explain/reference/partial-realization-descriptions.md
@@ -1,0 +1,54 @@
+# Partial realization descriptions
+
+A description reports what a producer actually knows. It can carry a selected
+family without a release, or several components with different amounts of
+detail. It never fills deployment defaults or changes the original request.
+
+Existing experiment evidence records and realized-form disclosures accept an
+optional `typed_description`. Each fact has a semantic pointer, knowledge state
+and an optional recursive value. Observer, version, time, window, achieved basis
+and limitations accompany the description; individual facts may override their
+provenance. `known-absent` means positive knowledge of absence, while
+`not-observed` and `withheld` provide no value. Collection coverage names its
+universe and profile separately from author collection closure.
+
+The Python reference API exposes `TypedRealizationDescriptionModel` from
+`raes_contracts.contracts`. `parse_realization_description` in
+`raes_contracts.description_reporting` admits bounded JSON without duplicate
+members. Private profile bindings retain exact coordinates and inert values;
+`admit_description_profiles` requires an explicit offline context and policy.
+Opaque acceptance does not enable semantic comparison.
+
+`assess_realization_description` in `raes_contracts.description_projection`
+compares against the original constraint document and its digest. Known facts
+can disprove exact requirements even when the report is partial. Whole-object
+conformance requires compatible complete coverage. Conflicting observations are
+retained during interchange and diagnosed during comparison; observations from
+different windows cannot silently become one state. Overlapping partial record
+projections require explicit reconciliation.
+
+`promote_description` in `raes_contracts.description_promotion` takes selected
+known scalar fact IDs, the original constraints, an actor, decision ID, time and
+new target identity/version. It returns a new document and transformation
+record after checked composition and refinement. It performs no authoring write
+or execution. The original document and unselected facts remain intact.
+
+Existing observation demand selectors reach describers before they acquire
+detail. Projection and protection run before retention. A selected structured
+fact containing an excluded descendant is omitted as a whole, preserving the
+exclusion without inventing a partial value. Producers can supply separate leaf
+facts when callers need finer selection. Backend selection implementations and
+scenario content belong to their downstream owners; RAE supplies these shared
+contracts and conformance checks.
+
+For profile data, the owner address must stay within the enclosing fact and the
+owner's contract/phase must match the evidence or run carrier. Nested profile
+provenance must agree with the fact's basis. Observed reference IDs must join the
+reference accepted by the outer evidence verifier; profile carriage alone does
+not verify them. The reporting API verifies an unqualified evidence-record ID,
+so retained claims cannot add a different kind, version, digest or path. It
+checks each retained fact's or coverage item's effective provenance; an
+overridden default does not become an additional evidence claim.
+Exhaustive description requests additionally require matching
+complete coverage for the selected scope and profile. Partial coverage remains
+reportable under selected demand.

--- a/docs/requirements/SEM-218/requirement.md
+++ b/docs/requirements/SEM-218/requirement.md
@@ -6,7 +6,7 @@ type: FUNCTIONAL
 priority: MUST
 wave: 2
 created_at: 2026-04-05T00:54:58.405111Z
-updated_at: 2026-09-06T00:00:00Z
+updated_at: 2026-09-12T00:00:00Z
 ---
 
 # SEM-218 — Explicitness And Realization Semantics
@@ -219,3 +219,30 @@ Current state: identified gap. Honest portability requires normative semantics f
 - IMPLEMENTS → GITHUB_ISSUE `1204` (Recursive authority through admitted preparation and results)
 - IMPLEMENTS → SPEC `specs/sdl/backend-realization-preparation.md`
 - IMPLEMENTS → SPEC `specs/sdl/plan-realization-profiles.md`
+
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_contracts/contracts/realization_descriptions.py`
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_contracts/description_projection.py`
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_contracts/_description_assertions.py`
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_contracts/description_promotion.py`
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_contracts/description_reporting.py`
+- TESTS → TEST `implementations/python/tests/test_issue_1209_descriptions.py`
+- TESTS → TEST `implementations/python/tests/test_issue_1209_description_relations.py`
+- TESTS → TEST `implementations/python/tests/test_issue_1209_description_lifecycle.py`
+- IMPLEMENTS → GITHUB_ISSUE `1209` (Typed partial descriptions and explicit selected-fact promotion)
+- DOCUMENTS → DOCUMENTATION `docs/decisions/issue-1209-clause-mapping.md`
+- DOCUMENTS → DOCUMENTATION `docs/explain/reference/partial-realization-descriptions.md`
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_contracts/contracts/experiment_evidence.py`
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_contracts/observation_reporting.py`
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_runtime/observation_execution.py`
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_runtime/observation_results.py`
+- TESTS → TEST `implementations/python/tests/test_issue_1209_policy_ownership.py`
+- TESTS → TEST `implementations/python/tests/test_specification_coverage.py` (Replay of source-bound semantic evidence after description contract changes)
+- TESTS → TEST `implementations/python/tests/test_formal_semantic_validation.py` (Replay of source-bound semantic evidence after description contract changes)
+- TESTS → TEST `implementations/python/tests/test_issue_989_versioned_evidence.py` (Source-bound capture provenance and strict supported-release regression checks)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_contracts/description_coverage.py` (Shared requested and authored coverage matching)
+- TESTS → TEST `implementations/python/tests/test_issue_1209_description_review.py` (Coverage, ownership, provenance and protection review regressions)
+- TESTS → TEST `implementations/python/tests/test_issue_1209_description_profiles.py` (Coverage, ownership, provenance and protection review regressions)
+- TESTS → TEST `implementations/python/tests/test_issue_1209_description_evidence.py` (Effective provenance and complete evidence-reference identity)
+- TESTS → TEST `implementations/python/tests/test_specification_coverage_units.py` (Independent evidence arithmetic and integrity fixtures)
+- TESTS → TEST `implementations/python/tests/test_formal_semantic_validation_review.py` (Replay, provenance and anti-fabrication evidence controls)
+- TESTS → TEST `implementations/python/tests/evidence_test_fixtures.py` (Isolated shared evidence fixtures)

--- a/docs/research/formal-semantic-validation/analysis-v9.json
+++ b/docs/research/formal-semantic-validation/analysis-v9.json
@@ -1,0 +1,140 @@
+{
+  "analysis_id": "issue-1209-analysis-v9",
+  "claim": {
+    "allowed_evidence": [
+      "production parser and semantic-validator results",
+      "canonical compiled digests",
+      "participant contract regression tests",
+      "pinned protocol, corpus, and execution snapshot"
+    ],
+    "claim_id": "asr-530-formal-semantic-validation-retest",
+    "disallowed_evidence": [
+      "schema success as semantic proof",
+      "workflow reachability as network or exploit reachability",
+      "FM labels as gate outcomes",
+      "attribution as counterfactual proof",
+      "formal prose or maintainer confidence alone"
+    ],
+    "evidence_artifacts": [
+      "docs/research/formal-semantic-validation/protocol-v2.json",
+      "docs/research/formal-semantic-validation/corpus/manifest-v2.json",
+      "docs/research/formal-semantic-validation/execution-snapshot-v9.json",
+      "docs/research/formal-semantic-validation/evidence/finite-domain-satisfiable-v3.json",
+      "docs/research/formal-semantic-validation/evidence/finite-domain-unsatisfiable-v3.json",
+      "docs/research/formal-semantic-validation/evidence/typed-exploit-path-valid-v3.json",
+      "docs/research/formal-semantic-validation/evidence/typed-exploit-path-invalid-v3.json"
+    ],
+    "falsification_protocol": "Replay every retained and new case through its production entrypoint, require complete digest and evidence joins, execute participant fixtures, and derive status from the recorded outcomes.",
+    "objective_fail_criteria": "A supported negative passes, a positive fails, an observation drifts, a required participant case is missing, or weaker evidence is promoted to solver, exploit-path, runtime-stability, or counterfactual assurance.",
+    "objective_pass_criteria": "Every claim class has positive and negative cases, all supported cases reproduce the frozen outcome, every participant obligation has passing positive and negative fixtures, and unsupported classes remain untested.",
+    "statement": "At the recorded source-state digest, the retained RAES controls have the bounded statuses recorded here; historical releases are integrity evidence, not current replay evidence.",
+    "threats_to_validity": [
+      "The issue-specific corpus is intentionally small and does not enumerate every validator invariant.",
+      "The participant fixtures exercise reference production contracts and tests, not every independent backend realization.",
+      "The replay gate runs on one Python reference configuration and one pinned RAES revision.",
+      "Unsupported solver-level classes have protocol cases but no executable observations."
+    ]
+  },
+  "claim_results": [
+    {
+      "case_count": 2,
+      "claim_class_id": "schema-validity",
+      "evidence_status": "demonstrated",
+      "limitations": [
+        "Bounded to the named source/model structural controls."
+      ],
+      "matching_case_count": 2,
+      "participant_obligation_count": 0,
+      "replayable_case_count": 2,
+      "unsupported_case_count": 0
+    },
+    {
+      "case_count": 4,
+      "claim_class_id": "semantic-consistency",
+      "evidence_status": "partial",
+      "limitations": [
+        "Partial coverage of named static semantics and participant obligations, not universal consistency."
+      ],
+      "matching_case_count": 4,
+      "participant_obligation_count": 7,
+      "replayable_case_count": 4,
+      "unsupported_case_count": 0
+    },
+    {
+      "case_count": 2,
+      "claim_class_id": "graph-reachability",
+      "evidence_status": "partial",
+      "limitations": [
+        "Partial workflow control-flow reachability only; not network, service, or exploit reachability."
+      ],
+      "matching_case_count": 2,
+      "participant_obligation_count": 0,
+      "replayable_case_count": 2,
+      "unsupported_case_count": 0
+    },
+    {
+      "case_count": 4,
+      "claim_class_id": "constraint-satisfiability",
+      "evidence_status": "demonstrated",
+      "limitations": [
+        "Demonstrated only for raes-finite-domain-satisfiability-v1 and its pinned solver configuration."
+      ],
+      "matching_case_count": 4,
+      "participant_obligation_count": 0,
+      "replayable_case_count": 2,
+      "unsupported_case_count": 2
+    },
+    {
+      "case_count": 4,
+      "claim_class_id": "exploit-path-validity",
+      "evidence_status": "demonstrated",
+      "limitations": [
+        "Demonstrated only for the admitted snapshot, typed graph, query, semantics, and bounded search profile."
+      ],
+      "matching_case_count": 4,
+      "participant_obligation_count": 0,
+      "replayable_case_count": 2,
+      "unsupported_case_count": 2
+    },
+    {
+      "case_count": 2,
+      "claim_class_id": "determinism-stability",
+      "evidence_status": "partial",
+      "limitations": [
+        "Partial parse-to-compile repeatability only; runtime and backend determinism are untested."
+      ],
+      "matching_case_count": 2,
+      "participant_obligation_count": 0,
+      "replayable_case_count": 2,
+      "unsupported_case_count": 0
+    },
+    {
+      "case_count": 2,
+      "claim_class_id": "counterfactual-necessity",
+      "evidence_status": "untested",
+      "limitations": [
+        "Untested because no governed intervention or ablation entrypoint ran."
+      ],
+      "matching_case_count": 2,
+      "participant_obligation_count": 0,
+      "replayable_case_count": 0,
+      "unsupported_case_count": 2
+    }
+  ],
+  "corpus_revision": "2.0.0",
+  "evidence_status": "partial",
+  "execution_id": "issue-1209-execution-v9",
+  "generated_at": "2026-09-12",
+  "limitations": [
+    "Satisfiability is limited to raes-finite-domain-satisfiability-v1 and its exact translation, theory, and Z3 configuration.",
+    "The subset-minimal unsatisfiable core is not a universal proof certificate.",
+    "Exploit-path results are limited to the admitted snapshot, normalized graph, query, transition semantics, and bounded search profile.",
+    "A valid path is not backend execution and an invalid path is not real-world non-exploitability.",
+    "The production exploit-path JSON loader permits duplicate keys; the research loader rejects them without claiming stronger production behavior.",
+    "Participant replay inherits the host environment and is not described as hermetic.",
+    "Counterfactual necessity remains untested.",
+    "Scoped observation demand is not a claim class in this preregistration and is not promoted to demonstrated by this retest."
+  ],
+  "plain_language_outcome": "The pinned RAES revision replays every retained v1 control and demonstrates the bounded finite-domain satisfiability and typed exploit-path claims with complete production evidence. Semantic, workflow, and compile-stability claims remain partial, and counterfactual necessity remains untested.",
+  "protocol_revision": "2.0.0"
+}

--- a/docs/research/formal-semantic-validation/bundles/retest-v9.json
+++ b/docs/research/formal-semantic-validation/bundles/retest-v9.json
@@ -1,0 +1,122 @@
+{
+  "analysis_path": "docs/research/formal-semantic-validation/analysis-v9.json",
+  "analysis_sha256": "19489e2d6822590b7d7c6ff34e182fea430286977952c0d8023f3ffbbeac60cd",
+  "artifacts": [
+    {
+      "artifact_id": "finite-domain-satisfiable-v2-input",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/satisfiable-control.sdl.yaml",
+      "sha256": "0ca9eaba9dc47171f7a042dc6753faa6c820c65ee966538f9d65fac5342202e8"
+    },
+    {
+      "artifact_id": "finite-domain-satisfiable-v2-evidence",
+      "kind": "production-evidence",
+      "path": "docs/research/formal-semantic-validation/evidence/finite-domain-satisfiable-v3.json",
+      "sha256": "7d1f05f634f0b36e763de1ece6598641006c2dd570531aa7a1cfc23c74784146"
+    },
+    {
+      "artifact_id": "finite-domain-unsatisfiable-v2-input",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/unsatisfiable-control.sdl.yaml",
+      "sha256": "cfef56a1f56d5f0db9da195377fd75694bdd0f0b92932fdb8fafcbd3f7baf6c5"
+    },
+    {
+      "artifact_id": "finite-domain-unsatisfiable-v2-evidence",
+      "kind": "production-evidence",
+      "path": "docs/research/formal-semantic-validation/evidence/finite-domain-unsatisfiable-v3.json",
+      "sha256": "e31bb7245d62e25810e394008da3ef4dcbbb6dad85f6363138cedef93ddc5c47"
+    },
+    {
+      "artifact_id": "typed-exploit-path-valid-v2-input",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/exploit-path-valid-v2.json",
+      "sha256": "23693f83f135c35960c144ab3434e866acec2313dc5f467fcccc8a18044f8b96"
+    },
+    {
+      "artifact_id": "typed-exploit-path-valid-v2-evidence",
+      "kind": "production-evidence",
+      "path": "docs/research/formal-semantic-validation/evidence/typed-exploit-path-valid-v3.json",
+      "sha256": "800c36e9e2415c3187c7bf16b781b1c7f2515829e205d40673a3fa1acf76d33f"
+    },
+    {
+      "artifact_id": "typed-exploit-path-invalid-v2-input",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/exploit-path-invalid-v2.json",
+      "sha256": "ad6636d5334d381bfda8d22183120d3f6a697a6ad92300e101e8cd2328f2ecd7"
+    },
+    {
+      "artifact_id": "typed-exploit-path-invalid-v2-evidence",
+      "kind": "production-evidence",
+      "path": "docs/research/formal-semantic-validation/evidence/typed-exploit-path-invalid-v3.json",
+      "sha256": "01a611834924d0fb2c48fb9a6795441e1281ad12bd8dd128ffaa5756b452da0f"
+    },
+    {
+      "artifact_id": "schema-valid-control-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/schema-valid.sdl.yaml",
+      "sha256": "41a9adffdf9f5f2ccc2f887dcf7b15fba3b47c83a1af15f33db872c4a2449d67"
+    },
+    {
+      "artifact_id": "schema-unknown-field-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/schema-invalid-unknown-field.sdl.yaml",
+      "sha256": "51cf62319a86c95a2517995939d1f370573051835e4b55bb6d5beaf049640481"
+    },
+    {
+      "artifact_id": "semantic-resolved-objective-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/semantic-valid.sdl.yaml",
+      "sha256": "a074d75b1b420a47a740703deaff45c20ec1c5d846f660412929bc69ab0efb19"
+    },
+    {
+      "artifact_id": "semantic-dangling-assertion-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/semantic-invalid-dangling-ref.sdl.yaml",
+      "sha256": "ebdb18e5a5288189daccdc5111b5915d2f0d40a3eef1f5dee6428c1c1d719ff9"
+    },
+    {
+      "artifact_id": "semantic-ambiguous-reference-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/semantic-invalid-ambiguous-ref.sdl.yaml",
+      "sha256": "653cbd2fd62e220d49fb86f80133884207df5ae6752846345ae3085b93f6e4ed"
+    },
+    {
+      "artifact_id": "semantic-feature-cycle-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/semantic-invalid-feature-cycle.sdl.yaml",
+      "sha256": "e1f66d95a9ad039687aec8cccbc8843b514072ff08e006c1b4ca6aa5cd8d4ed1"
+    },
+    {
+      "artifact_id": "workflow-reachable-control-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/workflow-reachable.sdl.yaml",
+      "sha256": "54c40ceb98ad47247447d737973b2c55e8fb2045e209c7545c4fb20cf42dc3dc"
+    },
+    {
+      "artifact_id": "workflow-unreachable-step-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/workflow-unreachable.sdl.yaml",
+      "sha256": "ef22ef2e260f1a7fd92d286f9b571716436b192ddfd54aea7bdfcfdda4ca52a2"
+    },
+    {
+      "artifact_id": "compile-repeatability-control-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/determinism-a.sdl.yaml",
+      "sha256": "0bc40900d598c1af7a405d798ca19710405e53ced262d8733081abf12edf89fe"
+    },
+    {
+      "artifact_id": "compile-non-vacuity-control-comparison-fixture",
+      "kind": "corpus-input",
+      "path": "docs/research/formal-semantic-validation/corpus/determinism-b.sdl.yaml",
+      "sha256": "d85338f89f20a45515b12da8640173c1a52e47eb17ca0f4f6b4f8f3306e863a1"
+    }
+  ],
+  "bundle_id": "raes-formal-semantic-validation",
+  "corpus_path": "docs/research/formal-semantic-validation/corpus/manifest-v2.json",
+  "corpus_sha256": "6adf37e76149c0361a0d5cceaecf161de66073039a80f065c735e46f391aed6a",
+  "protocol_path": "docs/research/formal-semantic-validation/protocol-v2.json",
+  "protocol_sha256": "abf94093e344bf495dfb04e8b0c5985c0beaab8ebb17a75e15c8674fa81b1a7c",
+  "revision": "10.0.0",
+  "snapshot_path": "docs/research/formal-semantic-validation/execution-snapshot-v9.json",
+  "snapshot_sha256": "38c6d7ac43bbc7e9436e866923f4fb31709dbbce66804232409abbe55c5fe15b"
+}

--- a/docs/research/formal-semantic-validation/bundles/retest-v9.json
+++ b/docs/research/formal-semantic-validation/bundles/retest-v9.json
@@ -118,5 +118,5 @@
   "protocol_sha256": "abf94093e344bf495dfb04e8b0c5985c0beaab8ebb17a75e15c8674fa81b1a7c",
   "revision": "10.0.0",
   "snapshot_path": "docs/research/formal-semantic-validation/execution-snapshot-v9.json",
-  "snapshot_sha256": "894cd644f25f1fded1a7224cf4ef065a3b526874d79c5b4cdec1c9e72ff2b763"
+  "snapshot_sha256": "f496e42d344ed1b64cb776ac26bc5f65f4e9cc24eaff6ab02efc2d2e59aa5508"
 }

--- a/docs/research/formal-semantic-validation/execution-snapshot-v9.json
+++ b/docs/research/formal-semantic-validation/execution-snapshot-v9.json
@@ -1,0 +1,657 @@
+{
+  "baseline": {
+    "execution_id": "issue-1204-execution-v8",
+    "release_path": "docs/research/formal-semantic-validation/bundles/retest-v8.json",
+    "release_revision": "9.0.0",
+    "release_sha256": "2e129b92d21f6ca0d209235dd1bca370484578efbd5968fe2633981535469d53"
+  },
+  "captured_at": "2026-09-12T21:19:44+00:00",
+  "commands": [
+    {
+      "argv": [
+        "implementations/python/.venv/bin/python",
+        "tools/check_formal_semantic_validation.py"
+      ],
+      "command_id": "bundle-replay",
+      "network": "disabled"
+    },
+    {
+      "argv": [
+        "implementations/python/.venv/bin/pytest",
+        "-q",
+        "implementations/python/tests/test_sem_208_participant_behavior.py::test_hidden_truth_disclosure_is_separate_from_observable_projection",
+        "implementations/python/tests/test_sem_208_participant_behavior.py::test_hidden_truth_cannot_be_observed_without_explicit_disclosure_rule",
+        "implementations/python/tests/test_sem_211_participant_action_semantics.py::test_action_contract_declares_sem_211_classes_and_compiles_them",
+        "implementations/python/tests/test_sem_211_participant_action_semantics.py::test_action_result_rejects_success_when_preconditions_are_unresolved",
+        "implementations/python/tests/test_run_308_concurrent_participant_execution.py::test_runtime_snapshot_publishes_joint_action_and_time_context_records",
+        "implementations/python/tests/test_run_308_concurrent_participant_execution.py::test_joint_action_record_contract_rejects_unordered_conflicting_writes",
+        "implementations/python/tests/test_participant_runtime_invariants.py::test_order_discipline_accepts_supported_order_claim_strengths",
+        "implementations/python/tests/test_participant_runtime_invariants.py::test_order_discipline_rejects_wall_clock_causality",
+        "implementations/python/tests/test_sem_212_participant_attribution_semantics.py::test_attribution_edge_round_trips_on_terminal_observation",
+        "implementations/python/tests/test_sem_212_participant_attribution_semantics.py::test_timestamp_adjacency_cannot_be_reported_as_strong_causality",
+        "implementations/python/tests/test_sem_215_participant_outcome_interpretation.py::test_outcome_interpretation_rule_parses_and_compiles_explicit_layers",
+        "implementations/python/tests/test_sem_215_participant_outcome_interpretation.py::test_local_action_success_does_not_imply_objective_success_without_rule_record",
+        "implementations/python/tests/test_realization_honesty_conformance.py::test_constructive_envelope_runs_positive_and_negative_honesty_probes",
+        "implementations/python/tests/test_realization_honesty_conformance.py::test_only_native_live_can_support_native_conformance"
+      ],
+      "command_id": "participant-fixtures",
+      "network": "disabled"
+    },
+    {
+      "argv": [
+        "implementations/python/.venv/bin/raes",
+        "processor",
+        "satisfiability",
+        "docs/research/formal-semantic-validation/corpus/satisfiable-control.sdl.yaml",
+        "--profile",
+        "raes-finite-domain-satisfiability-v1"
+      ],
+      "command_id": "finite-domain-satisfiable-v2",
+      "network": "disabled"
+    },
+    {
+      "argv": [
+        "implementations/python/.venv/bin/raes",
+        "processor",
+        "satisfiability",
+        "docs/research/formal-semantic-validation/corpus/unsatisfiable-control.sdl.yaml",
+        "--profile",
+        "raes-finite-domain-satisfiability-v1"
+      ],
+      "command_id": "finite-domain-unsatisfiable-v2",
+      "network": "disabled"
+    },
+    {
+      "argv": [
+        "implementations/python/.venv/bin/raes",
+        "processor",
+        "exploit-path",
+        "docs/research/formal-semantic-validation/corpus/exploit-path-valid-v2.json",
+        "--profile",
+        "raes-exploit-path-analysis-v1"
+      ],
+      "command_id": "typed-exploit-path-valid-v2",
+      "network": "disabled"
+    },
+    {
+      "argv": [
+        "implementations/python/.venv/bin/raes",
+        "processor",
+        "exploit-path",
+        "docs/research/formal-semantic-validation/corpus/exploit-path-invalid-v2.json",
+        "--profile",
+        "raes-exploit-path-analysis-v1"
+      ],
+      "command_id": "typed-exploit-path-invalid-v2",
+      "network": "disabled"
+    }
+  ],
+  "configuration_id": "raes-python-reference-offline-v9",
+  "corpus_revision": "2.0.0",
+  "deviations": [],
+  "execution_id": "issue-1209-execution-v9",
+  "execution_status": "complete",
+  "observations": [
+    {
+      "actual_outcome": "accepted",
+      "analysis_profile": null,
+      "case_id": "schema-valid-control",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/schema-valid.sdl.yaml"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "A passing minimal source does not establish semantic correctness."
+      ],
+      "replayable": true,
+      "result_digest": "f7d364ef384df8a1526b489501835b635021c860793b5764f91d956710d2250c",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "rejected",
+      "analysis_profile": null,
+      "case_id": "schema-unknown-field",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": "SDLParseError",
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/schema-invalid-unknown-field.sdl.yaml"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "The observation covers one unknown-field defect only."
+      ],
+      "replayable": true,
+      "result_digest": "f55d834b458f8e069e1c69061b4cc0a6d61e0e052bf90c670f2e6a5ad8b5bd98",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "accepted",
+      "analysis_profile": null,
+      "case_id": "semantic-resolved-objective",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/semantic-valid.sdl.yaml"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "This is a positive control for one objective-reference slice."
+      ],
+      "replayable": true,
+      "result_digest": "fadacf4359c97415f5433563e675d454c587917c85064b625d9756e4da1c4967",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "rejected",
+      "analysis_profile": null,
+      "case_id": "semantic-dangling-assertion",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": "SDLValidationError",
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/semantic-invalid-dangling-ref.sdl.yaml"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "A single dangling reference does not prove complete semantic coverage."
+      ],
+      "replayable": true,
+      "result_digest": "0207cf616b56708ca9b8c4499d3301abe22dbe52162cf8d58d3bec429d9db024",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "rejected",
+      "analysis_profile": null,
+      "case_id": "semantic-ambiguous-reference",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": "SDLValidationError",
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/semantic-invalid-ambiguous-ref.sdl.yaml"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "One namespace collision does not enumerate every ambiguity surface."
+      ],
+      "replayable": true,
+      "result_digest": "9da4a87797d228e0012ab6b30459f4892e41aa6f224a9840be035fee4a2eea73",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "rejected",
+      "analysis_profile": null,
+      "case_id": "semantic-feature-cycle",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": "SDLValidationError",
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/semantic-invalid-feature-cycle.sdl.yaml"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "One static dependency cycle does not establish general constraint satisfiability."
+      ],
+      "replayable": true,
+      "result_digest": "d15dbcd99fb4f20b965d7031b07dd6534576302270399c3fa656d29e7de02b83",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "accepted",
+      "analysis_profile": null,
+      "case_id": "workflow-reachable-control",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/workflow-reachable.sdl.yaml",
+        "implementations/python/tests/test_semantics_planner.py",
+        "specs/formal/workflows/state-machine.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "The graph is workflow control flow only."
+      ],
+      "replayable": true,
+      "result_digest": "b1b49649b54bd59d4ef357b39cf9158da90f4eae560f8dd756acf97bd0827a06",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "rejected",
+      "analysis_profile": null,
+      "case_id": "workflow-unreachable-step",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": "SDLValidationError",
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/workflow-unreachable.sdl.yaml",
+        "implementations/python/tests/test_semantics_planner.py",
+        "specs/formal/workflows/state-machine.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "The result does not establish network, service, participant, or exploit reachability."
+      ],
+      "replayable": true,
+      "result_digest": "bb931d19346ef9193408ae6c85deb4079704378fc5f00dc5f47a2817cff21943",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "unsupported",
+      "analysis_profile": null,
+      "case_id": "whole-scenario-satisfiable-request",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/decisions/issue-168-formal-semantic-validation-reachability-preflight.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "No governed whole-scenario constraint theory or solver exists."
+      ],
+      "replayable": false,
+      "result_digest": null,
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "unsupported",
+      "analysis_profile": null,
+      "case_id": "whole-scenario-unsatisfiable-request",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/decisions/issue-168-formal-semantic-validation-reachability-preflight.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Local checks cannot produce a whole-scenario unsat certificate."
+      ],
+      "replayable": false,
+      "result_digest": null,
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "unsupported",
+      "analysis_profile": null,
+      "case_id": "valid-exploit-path-request",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/decisions/issue-168-formal-semantic-validation-reachability-preflight.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "The issue-168 baseline had no canonical typed attack graph or path-query entrypoint."
+      ],
+      "replayable": false,
+      "result_digest": null,
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "unsupported",
+      "analysis_profile": null,
+      "case_id": "invalid-exploit-path-request",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/decisions/issue-168-formal-semantic-validation-reachability-preflight.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Vulnerability and topology declarations are not an invalid-path proof."
+      ],
+      "replayable": false,
+      "result_digest": null,
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "stable",
+      "analysis_profile": null,
+      "case_id": "compile-repeatability-control",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/determinism-a.sdl.yaml",
+        "implementations/python/tests/test_pipeline_determinism.py"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "The witness ends at compiled output."
+      ],
+      "replayable": true,
+      "result_digest": "595d1c0c3cc90ac28ba61290f609b6f56d2cb0fa81f2b3de68e7fc4b004da6d7",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "distinguishable",
+      "analysis_profile": null,
+      "case_id": "compile-non-vacuity-control",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/determinism-a.sdl.yaml",
+        "docs/research/formal-semantic-validation/corpus/determinism-b.sdl.yaml"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Distinct digests are a non-vacuity control, not semantic non-equivalence proof."
+      ],
+      "replayable": true,
+      "result_digest": "be75a4dd5ddcca749515c0cbb777fbb1f6d17d927b1c0572e90bf40700252217",
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "unsupported",
+      "analysis_profile": null,
+      "case_id": "necessity-witness-request",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/decisions/issue-168-formal-semantic-validation-reachability-preflight.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "No governed intervention or ablation protocol exists."
+      ],
+      "replayable": false,
+      "result_digest": null,
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "unsupported",
+      "analysis_profile": null,
+      "case_id": "non-necessity-control-request",
+      "configuration_digest": null,
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": null,
+      "evidence_artifact_path": null,
+      "evidence_artifact_sha256": null,
+      "evidence_digest": null,
+      "evidence_profile": null,
+      "evidence_refs": [
+        "docs/decisions/issue-168-formal-semantic-validation-reachability-preflight.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Attribution and negative fixtures do not demonstrate non-necessity."
+      ],
+      "replayable": false,
+      "result_digest": null,
+      "source_digest": null
+    },
+    {
+      "actual_outcome": "satisfiable",
+      "analysis_profile": "raes-finite-domain-satisfiability-v1",
+      "case_id": "finite-domain-satisfiable-v2",
+      "configuration_digest": "sha256:1204635e17e759e9ad3bd6be2ecb28c6de05c07ead6dfdd15936ed5d3d5b81b2",
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": "scenario-satisfiability-evidence/v1",
+      "evidence_artifact_path": "docs/research/formal-semantic-validation/evidence/finite-domain-satisfiable-v3.json",
+      "evidence_artifact_sha256": "7d1f05f634f0b36e763de1ece6598641006c2dd570531aa7a1cfc23c74784146",
+      "evidence_digest": "sha256:36e1a09e5ac51cfdd98be743c7b9e6073a6f3d02ac6377f60592fcb0a381a3e8",
+      "evidence_profile": "scenario-satisfiability-evidence/v1",
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/satisfiable-control.sdl.yaml",
+        "docs/research/formal-semantic-validation/evidence/finite-domain-satisfiable-v3.json",
+        "specs/formal/scenario-satisfiability/README.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Demonstrates only the pinned finite-domain theory, translation, solver profile, and source."
+      ],
+      "replayable": true,
+      "result_digest": "sha256:36e1a09e5ac51cfdd98be743c7b9e6073a6f3d02ac6377f60592fcb0a381a3e8",
+      "source_digest": "sha256:0ca9eaba9dc47171f7a042dc6753faa6c820c65ee966538f9d65fac5342202e8"
+    },
+    {
+      "actual_outcome": "unsatisfiable",
+      "analysis_profile": "raes-finite-domain-satisfiability-v1",
+      "case_id": "finite-domain-unsatisfiable-v2",
+      "configuration_digest": "sha256:1204635e17e759e9ad3bd6be2ecb28c6de05c07ead6dfdd15936ed5d3d5b81b2",
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": "scenario-satisfiability-evidence/v1",
+      "evidence_artifact_path": "docs/research/formal-semantic-validation/evidence/finite-domain-unsatisfiable-v3.json",
+      "evidence_artifact_sha256": "e31bb7245d62e25810e394008da3ef4dcbbb6dad85f6363138cedef93ddc5c47",
+      "evidence_digest": "sha256:8816c3a2898193280321559545cfacd462f38172fe7fbe7b005610401563b629",
+      "evidence_profile": "scenario-satisfiability-evidence/v1",
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/unsatisfiable-control.sdl.yaml",
+        "docs/research/formal-semantic-validation/evidence/finite-domain-unsatisfiable-v3.json",
+        "specs/formal/scenario-satisfiability/README.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "The subset-minimal core is evidence for the pinned translation and solver, not a proof certificate for arbitrary SDL."
+      ],
+      "replayable": true,
+      "result_digest": "sha256:8816c3a2898193280321559545cfacd462f38172fe7fbe7b005610401563b629",
+      "source_digest": "sha256:cfef56a1f56d5f0db9da195377fd75694bdd0f0b92932fdb8fafcbd3f7baf6c5"
+    },
+    {
+      "actual_outcome": "valid-path",
+      "analysis_profile": "raes-exploit-path-analysis-v1",
+      "case_id": "typed-exploit-path-valid-v2",
+      "configuration_digest": "sha256:7f8876d81feb77d3a3239be2fb8337de8885e2744f8786728ba23e4e6027bc0a",
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": "exploit-path-analysis-evidence/v1",
+      "evidence_artifact_path": "docs/research/formal-semantic-validation/evidence/typed-exploit-path-valid-v3.json",
+      "evidence_artifact_sha256": "800c36e9e2415c3187c7bf16b781b1c7f2515829e205d40673a3fa1acf76d33f",
+      "evidence_digest": "sha256:1c0fc5c8ecadc14e14b8993b4a3b59562a64bc35ef7dbf64f43ff7df9b5da472",
+      "evidence_profile": "exploit-path-analysis-evidence/v1",
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/exploit-path-valid-v2.json",
+        "docs/research/formal-semantic-validation/evidence/typed-exploit-path-valid-v3.json",
+        "specs/formal/exploit-path-analysis/README.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "The witness is bounded to the admitted snapshot, normalized graph, query, semantics, and search profile; it does not establish backend execution."
+      ],
+      "replayable": true,
+      "result_digest": "sha256:1c0fc5c8ecadc14e14b8993b4a3b59562a64bc35ef7dbf64f43ff7df9b5da472",
+      "source_digest": "sha256:23693f83f135c35960c144ab3434e866acec2313dc5f467fcccc8a18044f8b96"
+    },
+    {
+      "actual_outcome": "invalid-path",
+      "analysis_profile": "raes-exploit-path-analysis-v1",
+      "case_id": "typed-exploit-path-invalid-v2",
+      "configuration_digest": "sha256:7f8876d81feb77d3a3239be2fb8337de8885e2744f8786728ba23e4e6027bc0a",
+      "configuration_id": "raes-python-reference-offline-v9",
+      "diagnostic_kind": "exploit-path-analysis-evidence/v1",
+      "evidence_artifact_path": "docs/research/formal-semantic-validation/evidence/typed-exploit-path-invalid-v3.json",
+      "evidence_artifact_sha256": "01a611834924d0fb2c48fb9a6795441e1281ad12bd8dd128ffaa5756b452da0f",
+      "evidence_digest": "sha256:b43be52d3fe4bb66fa35e296de496f286daaf09d69975218ddc30fc79b5df6d0",
+      "evidence_profile": "exploit-path-analysis-evidence/v1",
+      "evidence_refs": [
+        "docs/research/formal-semantic-validation/corpus/exploit-path-invalid-v2.json",
+        "docs/research/formal-semantic-validation/evidence/typed-exploit-path-invalid-v3.json",
+        "specs/formal/exploit-path-analysis/README.md"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Structured rejection proves only that this bounded graph/query cannot reach its goal; it does not establish real-world non-exploitability."
+      ],
+      "replayable": true,
+      "result_digest": "sha256:b43be52d3fe4bb66fa35e296de496f286daaf09d69975218ddc30fc79b5df6d0",
+      "source_digest": "sha256:ad6636d5334d381bfda8d22183120d3f6a697a6ad92300e101e8cd2328f2ecd7"
+    }
+  ],
+  "participant_observations": [
+    {
+      "evidence_refs": [
+        "implementations/python/tests/test_sem_208_participant_behavior.py::test_hidden_truth_disclosure_is_separate_from_observable_projection",
+        "implementations/python/tests/test_sem_208_participant_behavior.py::test_hidden_truth_cannot_be_observed_without_explicit_disclosure_rule"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Covers the reference SDL/contract path, not every backend projection."
+      ],
+      "negative_outcome": "passed",
+      "obligation_id": "hidden-vs-visible-projection",
+      "positive_outcome": "passed"
+    },
+    {
+      "evidence_refs": [
+        "implementations/python/tests/test_sem_211_participant_action_semantics.py::test_action_contract_declares_sem_211_classes_and_compiles_them",
+        "implementations/python/tests/test_sem_211_participant_action_semantics.py::test_action_result_rejects_success_when_preconditions_are_unresolved"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Covers declared applicability and one unresolved-precondition failure."
+      ],
+      "negative_outcome": "passed",
+      "obligation_id": "fail-closed-action-applicability",
+      "positive_outcome": "passed"
+    },
+    {
+      "evidence_refs": [
+        "implementations/python/tests/test_run_308_concurrent_participant_execution.py::test_runtime_snapshot_publishes_joint_action_and_time_context_records",
+        "implementations/python/tests/test_run_308_concurrent_participant_execution.py::test_joint_action_record_contract_rejects_unordered_conflicting_writes"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Contract evidence does not prove every backend's live concurrency fidelity."
+      ],
+      "negative_outcome": "passed",
+      "obligation_id": "shared-state-effects",
+      "positive_outcome": "passed"
+    },
+    {
+      "evidence_refs": [
+        "implementations/python/tests/test_participant_runtime_invariants.py::test_order_discipline_accepts_supported_order_claim_strengths",
+        "implementations/python/tests/test_participant_runtime_invariants.py::test_order_discipline_rejects_wall_clock_causality"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Rejecting timestamp-only causality does not supply counterfactual proof."
+      ],
+      "negative_outcome": "passed",
+      "obligation_id": "ordering-before-causality",
+      "positive_outcome": "passed"
+    },
+    {
+      "evidence_refs": [
+        "implementations/python/tests/test_sem_212_participant_attribution_semantics.py::test_attribution_edge_round_trips_on_terminal_observation",
+        "implementations/python/tests/test_sem_212_participant_attribution_semantics.py::test_timestamp_adjacency_cannot_be_reported_as_strong_causality"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Attribution labels disclose basis; they do not demonstrate necessity."
+      ],
+      "negative_outcome": "passed",
+      "obligation_id": "evidence-labeled-attribution",
+      "positive_outcome": "passed"
+    },
+    {
+      "evidence_refs": [
+        "implementations/python/tests/test_sem_215_participant_outcome_interpretation.py::test_outcome_interpretation_rule_parses_and_compiles_explicit_layers",
+        "implementations/python/tests/test_sem_215_participant_outcome_interpretation.py::test_local_action_success_does_not_imply_objective_success_without_rule_record"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "The fixtures establish layer separation, not outcome validity in every realization."
+      ],
+      "negative_outcome": "passed",
+      "obligation_id": "participant-local-outcome-separation",
+      "positive_outcome": "passed"
+    },
+    {
+      "evidence_refs": [
+        "implementations/python/tests/test_realization_honesty_conformance.py::test_constructive_envelope_runs_positive_and_negative_honesty_probes",
+        "implementations/python/tests/test_realization_honesty_conformance.py::test_only_native_live_can_support_native_conformance"
+      ],
+      "execution_id": "issue-1209-execution-v9",
+      "limitations": [
+        "Reference conformance evidence remains bounded to declared realization profiles."
+      ],
+      "negative_outcome": "passed",
+      "obligation_id": "realization-profile-honesty",
+      "positive_outcome": "passed"
+    }
+  ],
+  "protocol_revision": "2.0.0",
+  "raes_revision": "c899612298f8d061e4e864c9b67b6fde2b913da0",
+  "source_state": {
+    "base_revision": "c899612298f8d061e4e864c9b67b6fde2b913da0",
+    "checkout_state": "modified",
+    "implementation_digest": "2db25d2c99203103075d7c1982f9a36bf01b59e7564a30d76dd08bdc5130b8a6",
+    "profile": "python-reference-source/v1"
+  },
+  "versions": {
+    "python": "3.13.13",
+    "raes": "3.5.0",
+    "z3_engine": "4.16.0",
+    "z3_solver": "4.16.0.0"
+  }
+}

--- a/docs/research/formal-semantic-validation/execution-snapshot-v9.json
+++ b/docs/research/formal-semantic-validation/execution-snapshot-v9.json
@@ -5,7 +5,7 @@
     "release_revision": "9.0.0",
     "release_sha256": "e7dde274931590d8cc0c8543e1d4785d8a7373f704a2694747fece3de76dd95c"
   },
-  "captured_at": "2026-09-12T22:31:28+00:00",
+  "captured_at": "2026-09-12T23:18:04+00:00",
   "commands": [
     {
       "argv": [
@@ -641,11 +641,11 @@
     }
   ],
   "protocol_revision": "2.0.0",
-  "raes_revision": "de2cbec6ed93bd2c6103278fe951611afd10d90e",
+  "raes_revision": "e00a7b2ed9965b6411916803a02691719c5a557d",
   "source_state": {
-    "base_revision": "de2cbec6ed93bd2c6103278fe951611afd10d90e",
+    "base_revision": "e00a7b2ed9965b6411916803a02691719c5a557d",
     "checkout_state": "modified",
-    "implementation_digest": "9c8605966b24ec83504bf7228289eb76fe6c9887b2efe2fe88c439873f9af340",
+    "implementation_digest": "7b85254bcd9254e12527ac94c365ed95afe9c230b93743c73d979ad055c009d3",
     "profile": "python-reference-source/v1"
   },
   "versions": {

--- a/docs/research/formal-semantic-validation/index.md
+++ b/docs/research/formal-semantic-validation/index.md
@@ -77,12 +77,17 @@ stability remain `partial`; counterfactual necessity remains `untested`.
   lifecycle. Two compiler result digests change from the pinned release
   7.0.0 baseline; the replayed stability and distinguishability outcomes do not.
   The original protocol and unsupported claims remain unchanged.
-- [`bundles/retest-v8.json`](bundles/retest-v8.json) is current release 9.0.0.
+- [`bundles/retest-v8.json`](bundles/retest-v8.json) preserves release 9.0.0.
   It binds [`execution-snapshot-v8.json`](execution-snapshot-v8.json) and
   [`analysis-v8.json`](analysis-v8.json) to the integrated Python dependency
   closures. Retained observations replay without drift from release 8.0.0.
   Previously pinned baseline captures retain their exact bytes; the new source
   identity is recorded here rather than repinning historical evidence.
+- [`bundles/retest-v9.json`](bundles/retest-v9.json) is current release 10.0.0.
+  It binds [`execution-snapshot-v9.json`](execution-snapshot-v9.json) and
+  [`analysis-v9.json`](analysis-v9.json) to the partial description contracts.
+  Every retained observation replays without drift from release 9.0.0; prior
+  captures and claim ceilings remain intact.
 - [`satisfiability-analysis-v1.json`](satisfiability-analysis-v1.json) is the
   preserved issue-826 historical supplement. It remains selected atomically in
   release 2.0 and is not independently combined with newer evidence.
@@ -127,7 +132,7 @@ Failed observations are evidence. A later product correction or RAES revision
 creates a new execution snapshot and analysis; it does not overwrite this
 record.
 
-Current validation requires explicit release 9.0.0, rejects unsupported future
+Current validation requires explicit release 10.0.0, rejects unsupported future
 or duplicate revisions, and never accepts an old/new output-digest pair as a
 substitute for replay. Historical releases (including the issue-826 supplement)
 undergo pin, shape, control, and internal-join checks without executing current

--- a/docs/research/specification-coverage/analysis-v8.json
+++ b/docs/research/specification-coverage/analysis-v8.json
@@ -1,0 +1,88 @@
+{
+  "analysis_id": "raes-standardized-specification-coverage-issue-1209-v8",
+  "backend_leakage": [],
+  "claim": {
+    "allowed_evidence": [
+      "pinned source metadata and bounded paraphrases",
+      "production parser, semantic, instantiation, admission, compiler, contract, and profile results",
+      "exact artifact digests and typed pointers",
+      "documented missing-concept and backend-specific dispositions"
+    ],
+    "claim_id": "raes-standardized-configurable-specification-coverage",
+    "disallowed_evidence": [
+      "field-count or schema breadth alone",
+      "the existing scenario stress corpus as the representative request corpus",
+      "free-form metadata as typed coverage",
+      "backend-private interpretation",
+      "post-hoc removal or repair of falsifying concepts"
+    ],
+    "evidence_artifacts": [
+      "docs/research/specification-coverage/protocol-v1.json",
+      "docs/research/specification-coverage/execution-snapshot-v8.json",
+      "docs/research/specification-coverage/analysis-v8.json"
+    ],
+    "falsification_protocol": "docs/research/specification-coverage/protocol-v1.json",
+    "objective_fail_criteria": "A load-bearing concept is missing or lossy, an applicable stage fails, or backend vocabulary is required in core SDL while the result claims success.",
+    "objective_pass_criteria": "Every load-bearing concept passes at every owning stage, backend-specific mechanics stay outside core SDL, and no requested concept is silently lost.",
+    "statement": "RAES provides a standardized configurable portable specification surface for the preregistered representative cyber-agent evaluation environment requirements without backend vocabulary in core SDL.",
+    "threats_to_validity": [
+      "The representative corpus contains four source strata and sixteen atomic concepts rather than every cyber-range requirement.",
+      "The reference processor and repository fixtures are not independent backend implementations.",
+      "No live range, simulator federation, or participant execution was part of this offline specification-coverage test."
+    ]
+  },
+  "classification_counts": {
+    "deliberately-backend-specific": 1,
+    "directly-expressible": 10,
+    "missing": 3,
+    "profile-or-manifest-constraint": 2
+  },
+  "evidence_status": "partial",
+  "execution_status": "complete",
+  "generated_at": "2026-09-12",
+  "limitations": [
+    "This result demonstrates bounded specification coverage, not universal cyber-range coverage, usability, adoption, backend substitution, or behavioral equivalence.",
+    "The three missing concepts are evidence, not implementation tasks within this snapshot.",
+    "The retained protocol does not test recursive realization or plan-level profile semantics; this release only re-establishes its original bounded coverage result against the current implementation."
+  ],
+  "load_bearing_results": {
+    "failed": 0,
+    "missing": 0,
+    "passed": 10,
+    "total": 10
+  },
+  "plain_language_outcome": "RAES preserved every issue-defined load-bearing concept through its tested typed stages without requiring backend fields in core SDL. The broader claim remains partial: the three preregistered missing-carrier slots were not run, which does not establish that those capabilities are absent from the current ecosystem.",
+  "protocol_revision": "1.0.0",
+  "request_results": [
+    {
+      "concept_count": 6,
+      "failed_stage_count": 0,
+      "missing_count": 0,
+      "request_id": "survey-representative-range",
+      "status": "demonstrated"
+    },
+    {
+      "concept_count": 5,
+      "failed_stage_count": 1,
+      "missing_count": 1,
+      "request_id": "cyborg-participant-evaluation",
+      "status": "partial"
+    },
+    {
+      "concept_count": 3,
+      "failed_stage_count": 1,
+      "missing_count": 1,
+      "request_id": "vsdl-configurable-infrastructure",
+      "status": "partial"
+    },
+    {
+      "concept_count": 2,
+      "failed_stage_count": 1,
+      "missing_count": 1,
+      "request_id": "cyber-dem-federation",
+      "status": "partial"
+    }
+  ],
+  "snapshot_id": "raes-standardized-specification-coverage-issue-1209-v8",
+  "snapshot_sha256": "51f9ac7c74bde9c99f11ae757ab5d9b0d0de1aeedb1093799b761e30d645a569"
+}

--- a/docs/research/specification-coverage/analysis-v8.json
+++ b/docs/research/specification-coverage/analysis-v8.json
@@ -84,5 +84,5 @@
     }
   ],
   "snapshot_id": "raes-standardized-specification-coverage-issue-1209-v8",
-  "snapshot_sha256": "9f99c721be382a5ef0736dbe600411e751df54fe475397422a8155c080334dec"
+  "snapshot_sha256": "9bdcc6b6dfc8a88e2d125d4e3ca58815c0e67522bbc94fe3964f94bb710f4903"
 }

--- a/docs/research/specification-coverage/bundles/raes-standardized-specification-coverage-issue-1209-v8.json
+++ b/docs/research/specification-coverage/bundles/raes-standardized-specification-coverage-issue-1209-v8.json
@@ -1,10 +1,10 @@
 {
   "analysis_path": "docs/research/specification-coverage/analysis-v8.json",
-  "analysis_sha256": "bf25b58bb1162ff20f39ac8f3500ba2cf813fa7df2f97105826a419b9db8f409",
+  "analysis_sha256": "91bc60bbeabfb3dc525b978fa85e8f7c2b316561c4e96d2395a3bc9daa26aeee",
   "bundle_id": "raes-standardized-specification-coverage",
   "protocol_path": "docs/research/specification-coverage/protocol-v1.json",
   "protocol_sha256": "e97a19e643e94c9e589dca823a63c6ce49d3329fe2a3cb888ab630838ed93125",
   "revision": "8.0.0",
   "snapshot_path": "docs/research/specification-coverage/execution-snapshot-v8.json",
-  "snapshot_sha256": "89eb7c8fc1200df9dc05f16fe321a1241d9aaad90a41ef64a7265e59ccb7b2ae"
+  "snapshot_sha256": "4376e773b34676e992122e176e859ac9cbc49cdf26c5b5c7feea4e16ea3a469e"
 }

--- a/docs/research/specification-coverage/bundles/raes-standardized-specification-coverage-issue-1209-v8.json
+++ b/docs/research/specification-coverage/bundles/raes-standardized-specification-coverage-issue-1209-v8.json
@@ -1,0 +1,10 @@
+{
+  "analysis_path": "docs/research/specification-coverage/analysis-v8.json",
+  "analysis_sha256": "71d2f6184aecc7caadae85e681ee35d32b99f31ee49f0db434e40d49082ccd5f",
+  "bundle_id": "raes-standardized-specification-coverage",
+  "protocol_path": "docs/research/specification-coverage/protocol-v1.json",
+  "protocol_sha256": "e97a19e643e94c9e589dca823a63c6ce49d3329fe2a3cb888ab630838ed93125",
+  "revision": "8.0.0",
+  "snapshot_path": "docs/research/specification-coverage/execution-snapshot-v8.json",
+  "snapshot_sha256": "c55453f6f9ccb7e6937ee7bf7a361d2410df7e826f23b5509ac0a806900dd816"
+}

--- a/docs/research/specification-coverage/execution-snapshot-v8.json
+++ b/docs/research/specification-coverage/execution-snapshot-v8.json
@@ -47,7 +47,7 @@
     "release_revision": "1.1.0",
     "release_sha256": "4020a1d56c7fe2831cec59ea64a12bbda9d38ccd94f93b916dd90f1a28f17fcb"
   },
-  "captured_at": "2026-09-12T22:31:28+00:00",
+  "captured_at": "2026-09-12T23:18:04+00:00",
   "concept_results": [
     {
       "backend_support": "not-evaluated",
@@ -641,7 +641,7 @@
   "execution_status": "complete",
   "implementation_surfaces": [
     {
-      "content_sha256": "13067f79515c755814363a414f7096e8a721cb27850507dff25fa8e9d5e31151",
+      "content_sha256": "9ff1fda3a745967ab89ea58da78c7f33ce12cfa51246e2094528476c9145f82a",
       "path": "implementations/python/packages/raes_contracts",
       "surface_id": "contract-models"
     },
@@ -665,13 +665,13 @@
   ],
   "protocol_revision": "1.0.0",
   "protocol_sha256": "e97a19e643e94c9e589dca823a63c6ce49d3329fe2a3cb888ab630838ed93125",
-  "raes_revision": "de2cbec6ed93bd2c6103278fe951611afd10d90e",
+  "raes_revision": "e00a7b2ed9965b6411916803a02691719c5a557d",
   "snapshot_id": "raes-standardized-specification-coverage-issue-1209-v8",
   "snapshot_revision": "8.0.0",
   "source_state": {
-    "base_revision": "de2cbec6ed93bd2c6103278fe951611afd10d90e",
+    "base_revision": "e00a7b2ed9965b6411916803a02691719c5a557d",
     "checkout_state": "modified",
-    "implementation_digest": "9c8605966b24ec83504bf7228289eb76fe6c9887b2efe2fe88c439873f9af340",
+    "implementation_digest": "7b85254bcd9254e12527ac94c365ed95afe9c230b93743c73d979ad055c009d3",
     "profile": "python-reference-source/v1"
   }
 }

--- a/docs/research/specification-coverage/execution-snapshot-v8.json
+++ b/docs/research/specification-coverage/execution-snapshot-v8.json
@@ -1,0 +1,677 @@
+{
+  "artifacts": [
+    {
+      "artifact_id": "enterprise-participant-sdl",
+      "kind": "sdl",
+      "path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+      "sha256": "7d9c2b8222a71c168b1a644d083e3e165047802ca5b5c75e57aa3d3c9a73a530",
+      "validator": "raes parse, semantic, instantiation/admission, and compiler pipeline"
+    },
+    {
+      "artifact_id": "port-range-sdl",
+      "kind": "sdl",
+      "path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+      "sha256": "a777f6a7ace95da145f1cce15431b667b47849c32b62aecb96643e2c7b780ed7",
+      "validator": "raes parse, semantic, instantiation/admission, and compiler pipeline"
+    },
+    {
+      "artifact_id": "experiment-task-contract",
+      "kind": "experiment-task",
+      "path": "contracts/fixtures/experiment-core/experiment-task-v1/valid/reference.json",
+      "sha256": "f3edf713ac6af26bad609136851c6dd434bfb87ce919a2d8c4414c1035deeafc",
+      "validator": "raes_contracts.contracts.ExperimentTaskModel"
+    },
+    {
+      "artifact_id": "apparatus-context-contract",
+      "kind": "experiment-apparatus-context",
+      "path": "contracts/fixtures/experiment-core/experiment-apparatus-context-v1/valid/reference.json",
+      "sha256": "e6fa559c5e961f0aab448d0f70dead24aa74fa8ba5f20e1b72f88e11473c9299",
+      "validator": "raes_contracts.contracts.ExperimentApparatusContextModel"
+    },
+    {
+      "artifact_id": "backend-profile",
+      "kind": "backend-profile",
+      "path": "contracts/profiles/backend/orchestration-capable.json",
+      "sha256": "f70b8505a5c0055416db86c533e2e5bf08b11e5a514f076223b6d6c36215a092",
+      "validator": "raes_contracts.backend_profiles.BackendProfileModel"
+    },
+    {
+      "artifact_id": "known-limitations",
+      "kind": "documentation",
+      "path": "docs/explain/sdl/limitations.md",
+      "sha256": "129cf17810aad4c51988bc872e28fe43ae95019a80053c42d800ff7e2b9cc93e",
+      "validator": "documentation evidence only"
+    }
+  ],
+  "baseline": {
+    "release_revision": "1.1.0",
+    "release_sha256": "4020a1d56c7fe2831cec59ea64a12bbda9d38ccd94f93b916dd90f1a28f17fcb"
+  },
+  "captured_at": "2026-09-12T21:19:44+00:00",
+  "concept_results": [
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "range-topology",
+      "rationale": "SDL nodes and infrastructure own host, network, link, and dependency meaning; the compiler emits canonical node deployment addresses.",
+      "stage_results": [
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Typed VM declaration.",
+          "outcome": "passed",
+          "pointer": "/nodes/shipping-portal",
+          "stage_id": "authored",
+          "validation_strength": "structural"
+        },
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Links and dependencies resolved.",
+          "outcome": "passed",
+          "pointer": "/infrastructure/shipping-portal",
+          "stage_id": "semantic",
+          "validation_strength": "semantic"
+        },
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Published instantiated shape admitted.",
+          "outcome": "passed",
+          "pointer": "/nodes/shipping-portal",
+          "stage_id": "instantiated",
+          "validation_strength": "phase-admitted"
+        },
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Canonical deployment address retained.",
+          "outcome": "passed",
+          "pointer": "/node_deployments/provision.node.shipping-portal",
+          "stage_id": "compiled",
+          "validation_strength": "compiled"
+        }
+      ],
+      "typed_pointer": "/nodes/shipping-portal"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "exercise-roles",
+      "rationale": "SDL entity roles own exercise responsibility without becoming control-plane identity or authorization.",
+      "stage_results": [
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Typed red role.",
+          "outcome": "passed",
+          "pointer": "/entities/enterprise-participant/role",
+          "stage_id": "authored",
+          "validation_strength": "structural"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Entity references validated.",
+          "outcome": "passed",
+          "pointer": "/entities/enterprise-participant",
+          "stage_id": "semantic",
+          "validation_strength": "semantic"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Role retained after instantiation.",
+          "outcome": "passed",
+          "pointer": "/entities/enterprise-participant/role",
+          "stage_id": "instantiated",
+          "validation_strength": "phase-admitted"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Role retained in entity specification.",
+          "outcome": "passed",
+          "pointer": "/entity_specs/enterprise-participant/role",
+          "stage_id": "compiled",
+          "validation_strength": "compiled"
+        }
+      ],
+      "typed_pointer": "/entities/enterprise-participant/role"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "evaluation-objectives",
+      "rationale": "SDL objectives own actor, target, window, and assertion-based success meaning while measures remain in experiment contracts.",
+      "stage_results": [
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Typed objective declaration.",
+          "outcome": "passed",
+          "pointer": "/objectives/demonstrate-handoff",
+          "stage_id": "authored",
+          "validation_strength": "structural"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Actor, targets, assertions, and workflow refs resolved.",
+          "outcome": "passed",
+          "pointer": "/objectives/demonstrate-handoff/success",
+          "stage_id": "semantic",
+          "validation_strength": "semantic"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Objective retained in admitted artifact.",
+          "outcome": "passed",
+          "pointer": "/objectives/demonstrate-handoff",
+          "stage_id": "instantiated",
+          "validation_strength": "phase-admitted"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Canonical objective address retained.",
+          "outcome": "passed",
+          "pointer": "/objectives/evaluation.objective.demonstrate-handoff",
+          "stage_id": "compiled",
+          "validation_strength": "compiled"
+        }
+      ],
+      "typed_pointer": "/objectives/demonstrate-handoff"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "control-workflows",
+      "rationale": "SDL workflows own the portable control graph and compile to canonical orchestration state contracts.",
+      "stage_results": [
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Typed control graph.",
+          "outcome": "passed",
+          "pointer": "/workflows/yard-recovery",
+          "stage_id": "authored",
+          "validation_strength": "structural"
+        },
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Step graph and objective refs validated.",
+          "outcome": "passed",
+          "pointer": "/workflows/yard-recovery/steps",
+          "stage_id": "semantic",
+          "validation_strength": "semantic"
+        },
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Workflow retained after instantiation.",
+          "outcome": "passed",
+          "pointer": "/workflows/yard-recovery",
+          "stage_id": "instantiated",
+          "validation_strength": "phase-admitted"
+        },
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Canonical control graph retained.",
+          "outcome": "passed",
+          "pointer": "/workflows/orchestration.workflow.yard-recovery",
+          "stage_id": "compiled",
+          "validation_strength": "compiled"
+        }
+      ],
+      "typed_pointer": "/workflows/yard-recovery"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "authored-evidence-expectations",
+      "rationale": "SDL evidence requirements own portable capture intent and remain distinct from evidence records and measures.",
+      "stage_results": [
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Typed capture obligation.",
+          "outcome": "passed",
+          "pointer": "/evidence_requirements/objective-truth-evidence",
+          "stage_id": "authored",
+          "validation_strength": "structural"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Source refs and bindings validated.",
+          "outcome": "passed",
+          "pointer": "/evidence_requirements/objective-truth-evidence",
+          "stage_id": "semantic",
+          "validation_strength": "semantic"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Evidence intent retained in admitted artifact.",
+          "outcome": "passed",
+          "pointer": "/evidence_requirements/objective-truth-evidence",
+          "stage_id": "instantiated",
+          "validation_strength": "phase-admitted"
+        }
+      ],
+      "typed_pointer": "/evidence_requirements/objective-truth-evidence"
+    },
+    {
+      "backend_support": "profile-bound",
+      "backend_vocabulary_occurrences": [],
+      "classification": "profile-or-manifest-constraint",
+      "completeness_disposition": "implemented",
+      "concept_id": "apparatus-selection-constraints",
+      "rationale": "The experiment task contract binds processor/backend identities, manifest refs, and capabilities outside SDL.",
+      "stage_results": [
+        {
+          "artifact_path": "contracts/fixtures/experiment-core/experiment-task-v1/valid/reference.json",
+          "diagnostic_codes": [],
+          "note": "Closed ExperimentTaskModel validated.",
+          "outcome": "passed",
+          "pointer": "/apparatus_constraints/allowed_backend_refs/0",
+          "stage_id": "contract",
+          "validation_strength": "contract"
+        }
+      ],
+      "typed_pointer": "/apparatus_constraints/allowed_backend_refs/0"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "participant-agent",
+      "rationale": "SDL agents own participant entity, knowledge, actions, observation boundaries, and operating scope.",
+      "stage_results": [
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Typed participant declaration.",
+          "outcome": "passed",
+          "pointer": "/agents/participant-agent",
+          "stage_id": "authored",
+          "validation_strength": "structural"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Participant refs and scope validated.",
+          "outcome": "passed",
+          "pointer": "/agents/participant-agent/observation_boundaries",
+          "stage_id": "semantic",
+          "validation_strength": "semantic"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Participant retained in admitted artifact.",
+          "outcome": "passed",
+          "pointer": "/agents/participant-agent",
+          "stage_id": "instantiated",
+          "validation_strength": "phase-admitted"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Compiled participant scope retained.",
+          "outcome": "passed",
+          "pointer": "/agent_specs/participant-agent",
+          "stage_id": "compiled",
+          "validation_strength": "compiled"
+        }
+      ],
+      "typed_pointer": "/agents/participant-agent"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "participant-action-contract",
+      "rationale": "The action contract declares portable preconditions, effects, observations, evidence, and failure classes without a runner command.",
+      "stage_results": [
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Typed action contract.",
+          "outcome": "passed",
+          "pointer": "/action_contracts/probe-customer-portal-login",
+          "stage_id": "authored",
+          "validation_strength": "structural"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Action refs and evidence bindings validated.",
+          "outcome": "passed",
+          "pointer": "/action_contracts/probe-customer-portal-login/effects",
+          "stage_id": "semantic",
+          "validation_strength": "semantic"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Action retained in admitted artifact.",
+          "outcome": "passed",
+          "pointer": "/action_contracts/probe-customer-portal-login",
+          "stage_id": "instantiated",
+          "validation_strength": "phase-admitted"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Canonical action address retained.",
+          "outcome": "passed",
+          "pointer": "/action_contracts/participant.action-contract.probe-customer-portal-login",
+          "stage_id": "compiled",
+          "validation_strength": "compiled"
+        }
+      ],
+      "typed_pointer": "/action_contracts/probe-customer-portal-login"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "participant-observation-boundary",
+      "rationale": "The observation boundary separately declares visible, hidden, and evidence-only information with transition rules.",
+      "stage_results": [
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Typed observation boundary.",
+          "outcome": "passed",
+          "pointer": "/observation_boundaries/participant-view",
+          "stage_id": "authored",
+          "validation_strength": "structural"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Information refs and transitions validated.",
+          "outcome": "passed",
+          "pointer": "/observation_boundaries/participant-view/view_rules",
+          "stage_id": "semantic",
+          "validation_strength": "semantic"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Boundary retained in admitted artifact.",
+          "outcome": "passed",
+          "pointer": "/observation_boundaries/participant-view",
+          "stage_id": "instantiated",
+          "validation_strength": "phase-admitted"
+        },
+        {
+          "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Canonical boundary address retained.",
+          "outcome": "passed",
+          "pointer": "/observation_boundaries/participant.observation-boundary.participant-view",
+          "stage_id": "compiled",
+          "validation_strength": "compiled"
+        }
+      ],
+      "typed_pointer": "/observation_boundaries/participant-view"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "evaluation-measure",
+      "rationale": "ExperimentTaskModel owns metric construct, unit, direction, aggregation, and evidence requirements outside SDL objectives.",
+      "stage_results": [
+        {
+          "artifact_path": "contracts/fixtures/experiment-core/experiment-task-v1/valid/reference.json",
+          "diagnostic_codes": [],
+          "note": "Closed task contract validated.",
+          "outcome": "passed",
+          "pointer": "/evaluation_protocol/metric_definitions/foothold-achieved",
+          "stage_id": "contract",
+          "validation_strength": "contract"
+        }
+      ],
+      "typed_pointer": "/evaluation_protocol/metric_definitions/foothold-achieved"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "missing",
+      "completeness_disposition": "documented-gap",
+      "concept_id": "participant-tool-affordance",
+      "rationale": "This preregistered matrix has no tested carrier for participant tool affordances. The retained missing classification records missing coverage evidence, not the absence of current participant-behavior capabilities.",
+      "stage_results": [
+        {
+          "artifact_path": "docs/explain/sdl/limitations.md",
+          "diagnostic_codes": [],
+          "note": "The preregistered carrier slot was not run; metadata does not substitute for a typed coverage test.",
+          "outcome": "not_run",
+          "pointer": null,
+          "stage_id": "authored",
+          "validation_strength": "not-applicable"
+        }
+      ],
+      "typed_pointer": null
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "directly-expressible",
+      "completeness_disposition": "implemented",
+      "concept_id": "resource-constrained-topology",
+      "rationale": "SDL node resources and infrastructure dependencies express portable resource intent without provider resource identifiers.",
+      "stage_results": [
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Typed CPU and memory declaration.",
+          "outcome": "passed",
+          "pointer": "/nodes/shipping-portal/resources",
+          "stage_id": "authored",
+          "validation_strength": "structural"
+        },
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Resource-bearing topology validated.",
+          "outcome": "passed",
+          "pointer": "/infrastructure/shipping-portal",
+          "stage_id": "semantic",
+          "validation_strength": "semantic"
+        },
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Constraints retained in admitted artifact.",
+          "outcome": "passed",
+          "pointer": "/nodes/shipping-portal/resources",
+          "stage_id": "instantiated",
+          "validation_strength": "phase-admitted"
+        },
+        {
+          "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+          "diagnostic_codes": [],
+          "note": "Deployment specification retains resource intent.",
+          "outcome": "passed",
+          "pointer": "/node_deployments/provision.node.shipping-portal",
+          "stage_id": "compiled",
+          "validation_strength": "compiled"
+        }
+      ],
+      "typed_pointer": "/nodes/shipping-portal/resources"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "missing",
+      "completeness_disposition": "documented-gap",
+      "concept_id": "formal-constraint-satisfiability",
+      "rationale": "This coverage matrix did not exercise a solver-backed carrier. The separate formal-semantic-validation release demonstrates its bounded finite-domain profile; that result is not silently imported into this protocol's missing carrier slot.",
+      "stage_results": [
+        {
+          "artifact_path": "docs/explain/sdl/limitations.md",
+          "diagnostic_codes": [],
+          "note": "No coverage-carrier execution was performed here; independent solver evidence does not change this preregistered denominator.",
+          "outcome": "not_run",
+          "pointer": null,
+          "stage_id": "semantic",
+          "validation_strength": "not-applicable"
+        }
+      ],
+      "typed_pointer": null
+    },
+    {
+      "backend_support": "profile-bound",
+      "backend_vocabulary_occurrences": [
+        {
+          "allowed": true,
+          "artifact_path": "source:vsdl-paper",
+          "pointer": "source sections 4-5",
+          "reason": "Legitimate VSDL realization vocabulary, not RAES core SDL structure.",
+          "term": "OpenStack/Terraform/Packer"
+        }
+      ],
+      "classification": "deliberately-backend-specific",
+      "completeness_disposition": "external",
+      "concept_id": "provider-specific-provisioning",
+      "rationale": "Provider image selection and provisioning engines are realization mechanics and therefore remain outside core SDL.",
+      "stage_results": [
+        {
+          "artifact_path": "contracts/profiles/backend/orchestration-capable.json",
+          "diagnostic_codes": [],
+          "note": "The portable boundary requires backend contracts; it does not standardize a provider engine.",
+          "outcome": "not_applicable",
+          "pointer": "/required_contracts",
+          "stage_id": "realization-disclosure",
+          "validation_strength": "profile"
+        }
+      ],
+      "typed_pointer": null
+    },
+    {
+      "backend_support": "profile-bound",
+      "backend_vocabulary_occurrences": [],
+      "classification": "profile-or-manifest-constraint",
+      "completeness_disposition": "implemented",
+      "concept_id": "apparatus-clock-context",
+      "rationale": "ExperimentApparatusContextModel records clock authority, time domain, and synchronization as apparatus facts outside scenario meaning.",
+      "stage_results": [
+        {
+          "artifact_path": "contracts/fixtures/experiment-core/experiment-apparatus-context-v1/valid/reference.json",
+          "diagnostic_codes": [],
+          "note": "Closed apparatus context contract validated.",
+          "outcome": "passed",
+          "pointer": "/clocks/0",
+          "stage_id": "contract",
+          "validation_strength": "contract"
+        }
+      ],
+      "typed_pointer": "/clocks/0"
+    },
+    {
+      "backend_support": "not-evaluated",
+      "backend_vocabulary_occurrences": [],
+      "classification": "missing",
+      "completeness_disposition": "documented-gap",
+      "concept_id": "federated-object-event-exchange",
+      "rationale": "The federated cyber object/event exchange carrier was not exercised by this preregistered matrix. Runtime event internals are not treated as equivalent evidence.",
+      "stage_results": [
+        {
+          "artifact_path": "docs/explain/sdl/limitations.md",
+          "diagnostic_codes": [],
+          "note": "The missing coverage-carrier test is recorded explicitly, without inferring an ecosystem-wide capability absence.",
+          "outcome": "not_run",
+          "pointer": null,
+          "stage_id": "contract",
+          "validation_strength": "not-applicable"
+        }
+      ],
+      "typed_pointer": null
+    }
+  ],
+  "deviations": [
+    {
+      "artifact_path": "examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml",
+      "baseline_sha256": "54ba1a60220e27a55da9cd2a407d7d3ab836fa54460d0b0c6cad87c2e744ddbb",
+      "rationale": "Explicit current-source capture; no historical/current digest equivalence is claimed.",
+      "retest_sha256": "7d9c2b8222a71c168b1a644d083e3e165047802ca5b5c75e57aa3d3c9a73a530"
+    },
+    {
+      "artifact_path": "examples/scenarios/port-authority-surge-response.sdl.yaml",
+      "baseline_sha256": "a27c7a64e0c5c618fadaccafdf1a4e71600170a8b77b983190822b5141f00dec",
+      "rationale": "Explicit current-source capture; no historical/current digest equivalence is claimed.",
+      "retest_sha256": "a777f6a7ace95da145f1cce15431b667b47849c32b62aecb96643e2c7b780ed7"
+    },
+    {
+      "artifact_path": "contracts/fixtures/experiment-core/experiment-task-v1/valid/reference.json",
+      "baseline_sha256": "21952a752f4e8581a9fc3b872e4bc308150548170d38bcfc83dbbe35ff5e0b9f",
+      "rationale": "Explicit current-source capture; no historical/current digest equivalence is claimed.",
+      "retest_sha256": "f3edf713ac6af26bad609136851c6dd434bfb87ce919a2d8c4414c1035deeafc"
+    },
+    {
+      "artifact_path": "contracts/fixtures/experiment-core/experiment-apparatus-context-v1/valid/reference.json",
+      "baseline_sha256": "9536d897a09cbc6920e667e4f8f9371e51307aa0b3b5ff3c7de682dd783420ab",
+      "rationale": "Explicit current-source capture; no historical/current digest equivalence is claimed.",
+      "retest_sha256": "e6fa559c5e961f0aab448d0f70dead24aa74fa8ba5f20e1b72f88e11473c9299"
+    }
+  ],
+  "execution_status": "complete",
+  "implementation_surfaces": [
+    {
+      "content_sha256": "13067f79515c755814363a414f7096e8a721cb27850507dff25fa8e9d5e31151",
+      "path": "implementations/python/packages/raes_contracts",
+      "surface_id": "contract-models"
+    },
+    {
+      "content_sha256": "4daa6e38995fbf1704de6ab8a0574f28078e397a609f56c3b3ff08d5443273ec",
+      "path": "implementations/python/packages/raes_processor",
+      "surface_id": "processor-pipeline"
+    },
+    {
+      "content_sha256": "06bb7e348db6e9409a668ea4a9ca846cee8bde4f93913399d7310aa4aaf67ce8",
+      "path": "implementations/python/packages/raes",
+      "surface_id": "sdl-pipeline"
+    }
+  ],
+  "limitations": [
+    "The execution validates the pinned reference implementation and published contracts, not an independent backend.",
+    "Repository-owned examples are exact execution artifacts but are not themselves the literature-derived request corpus; the protocol's requests and concepts are.",
+    "No live range, participant, simulator federation, or provider provisioning engine was executed.",
+    "Missing concepts remain frozen in this snapshot and require separately scoped product work before a later rerun.",
+    "This current capture re-executes the retained specification-coverage protocol against the recursive realization implementation; it does not add recursive realization or plan-profile support claims to that preregistered protocol."
+  ],
+  "protocol_revision": "1.0.0",
+  "protocol_sha256": "e97a19e643e94c9e589dca823a63c6ce49d3329fe2a3cb888ab630838ed93125",
+  "raes_revision": "c899612298f8d061e4e864c9b67b6fde2b913da0",
+  "snapshot_id": "raes-standardized-specification-coverage-issue-1209-v8",
+  "snapshot_revision": "8.0.0",
+  "source_state": {
+    "base_revision": "c899612298f8d061e4e864c9b67b6fde2b913da0",
+    "checkout_state": "modified",
+    "implementation_digest": "2db25d2c99203103075d7c1982f9a36bf01b59e7564a30d76dd08bdc5130b8a6",
+    "profile": "python-reference-source/v1"
+  }
+}

--- a/docs/research/specification-coverage/index.md
+++ b/docs/research/specification-coverage/index.md
@@ -48,9 +48,14 @@ this run does not repair them.
   after integration with the unified control-plane mutation lifecycle.
   The original protocol and missing-concept denominator remain unchanged.
 - [`execution-snapshot-v7.json`](execution-snapshot-v7.json) and
-  [`analysis-v7.json`](analysis-v7.json) are current release 7.0.0. They bind
+  [`analysis-v7.json`](analysis-v7.json) preserve release 7.0.0. They bind
   the integrated Python dependency closures to fresh source-state evidence,
   retaining the exact historical captures and original coverage denominator.
+
+- [`execution-snapshot-v8.json`](execution-snapshot-v8.json) and
+  [`analysis-v8.json`](analysis-v8.json) are current release 8.0.0. They bind
+  partial description contracts to freshly replayed evidence with the same
+  preregistered classifications and missing-concept denominator.
 
 Historical captures are checked for closed shapes, frozen analysis joins, and
 exact archived source bytes, without executing current code. The ten source
@@ -60,7 +65,7 @@ recovered. Recovery revisions are not substituted for the capture's declared
 revision; a matching archive proves the frozen byte pin, not the historical
 working-tree provenance. No network or Git history is required for validation.
 
-Current validation requires release 7.0.0 and rejects duplicate or unsupported
+Current validation requires release 8.0.0 and rejects duplicate or unsupported
 future revisions. It executes current artifacts, requires exact source and
 package hashes, and checks all passing stage pointers. `source_state` discloses
 the base Git commit, modified checkout state, and exact implementation digest;

--- a/implementations/python/packages/raes_contracts/_description_assertions.py
+++ b/implementations/python/packages/raes_contracts/_description_assertions.py
@@ -1,0 +1,69 @@
+"""Compare only overlapping descriptive assertions, without inferring closure."""
+
+from collections import defaultdict
+
+from .canonical import canonical_json_digest
+from .contracts.realization_descriptions import TypedRealizationDescriptionModel
+from .realization_structure import (
+    RealizationKeyedCollectionConstraint,
+    RealizationLiteral,
+    RealizationRecordConstraint,
+)
+from .realization_structure._common import pointer_tokens
+from .realization_structure._models import identity_key
+
+
+def _value_assertions(path, value):
+    if isinstance(value, RealizationLiteral):
+        yield path, canonical_json_digest({"literal_type": type(value.value).__name__, "literal": value.value})
+        return
+    yield path, value.kind
+    if isinstance(value, RealizationRecordConstraint):
+        children = value.fields.items()
+    elif isinstance(value, RealizationKeyedCollectionConstraint):
+        yield (
+            path,
+            canonical_json_digest({"identity_fields": value.identity_fields, "collection_kind": value.collection_kind}),
+        )
+        children = (("@" + identity_key(member.identity), member.constraint) for member in value.members)
+    else:
+        children = ((str(index), child) for index, child in enumerate(value.items))
+    for name, child in children:
+        yield from _value_assertions((*path, name), child)
+
+
+def assertion_conflict(description: TypedRealizationDescriptionModel) -> str | None:
+    """Return a conflict category; separate windows never prove a common state."""
+    windows = defaultdict(lambda: defaultdict(set))
+    absent = defaultdict(set)
+    for fact in description.facts:
+        if fact.state == "contradictory":
+            return "contradictory"
+        if fact.state not in {"known", "known-absent"}:
+            continue
+        source = fact.provenance or description.provenance
+        window = canonical_json_digest(
+            {
+                "time": source.recorded_at,
+                "window": source.window_ref,
+                "operation": source.operation_ref.model_dump(mode="json") if source.operation_ref else None,
+                "configuration": source.configuration_ref.model_dump(mode="json") if source.configuration_ref else None,
+            }
+        )
+        assertions = windows[window]
+        path = pointer_tokens(fact.subject)
+        if fact.state == "known-absent":
+            absent[window].add(path)
+        else:
+            # Each fact can assert multiple compatible markers at one node.
+            local = defaultdict(set)
+            for address, marker in _value_assertions(path, fact.value):
+                local[address].add(marker)
+            for address, markers in local.items():
+                assertions[address].add(frozenset(markers))
+    for window, assertions in windows.items():
+        if any(len(values) > 1 for values in assertions.values()):
+            return "contradictory"
+        if any(path[:length] in absent[window] for path in assertions for length in range(len(path) + 1)):
+            return "contradictory"
+    return "different-windows" if len(windows) > 1 else None

--- a/implementations/python/packages/raes_contracts/_description_assertions.py
+++ b/implementations/python/packages/raes_contracts/_description_assertions.py
@@ -1,69 +1,102 @@
 """Compare only overlapping descriptive assertions, without inferring closure."""
 
 from collections import defaultdict
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
 
 from .canonical import canonical_json_digest
-from .contracts.realization_descriptions import TypedRealizationDescriptionModel
+from .contracts.realization_descriptions import (
+    DescriptionFactModel,
+    DescriptionProvenanceModel,
+    TypedRealizationDescriptionModel,
+)
 from .realization_structure import (
     RealizationKeyedCollectionConstraint,
     RealizationLiteral,
     RealizationRecordConstraint,
+    RealizationSequenceConstraint,
+    RecursiveRealizationStructure,
 )
 from .realization_structure._common import pointer_tokens
 from .realization_structure._models import identity_key
 
+Address = tuple[str, ...]
 
-def _value_assertions(path, value):
+
+def _node_markers(value: RecursiveRealizationStructure) -> tuple[str, ...]:
     if isinstance(value, RealizationLiteral):
-        yield path, canonical_json_digest({"literal_type": type(value.value).__name__, "literal": value.value})
-        return
-    yield path, value.kind
+        markers = (canonical_json_digest({"literal_type": type(value.value).__name__, "literal": value.value}),)
+    elif isinstance(value, RealizationKeyedCollectionConstraint):
+        markers = (
+            value.kind,
+            canonical_json_digest({"identity_fields": value.identity_fields, "collection_kind": value.collection_kind}),
+        )
+    else:
+        markers = (value.kind,)
+    return markers
+
+
+def _value_children(value: RecursiveRealizationStructure) -> Iterable[tuple[str, RecursiveRealizationStructure]]:
+    children: Iterable[tuple[str, RecursiveRealizationStructure]] = ()
     if isinstance(value, RealizationRecordConstraint):
         children = value.fields.items()
     elif isinstance(value, RealizationKeyedCollectionConstraint):
-        yield (
-            path,
-            canonical_json_digest({"identity_fields": value.identity_fields, "collection_kind": value.collection_kind}),
-        )
         children = (("@" + identity_key(member.identity), member.constraint) for member in value.members)
-    else:
+    elif isinstance(value, RealizationSequenceConstraint):
         children = ((str(index), child) for index, child in enumerate(value.items))
-    for name, child in children:
+    return children
+
+
+def _value_assertions(path: Address, value: RecursiveRealizationStructure) -> Iterator[tuple[Address, str]]:
+    for marker in _node_markers(value):
+        yield path, marker
+    for name, child in _value_children(value):
         yield from _value_assertions((*path, name), child)
+
+
+@dataclass
+class _WindowAssertions:
+    markers: dict[Address, set[frozenset[str]]] = field(default_factory=lambda: defaultdict(set))
+    absent: set[Address] = field(default_factory=set)
+
+    def add(self, fact: DescriptionFactModel) -> None:
+        path = pointer_tokens(fact.subject)
+        if fact.state == "known-absent":
+            self.absent.add(path)
+        else:
+            assert fact.value is not None
+            local: dict[Address, set[str]] = defaultdict(set)
+            for address, marker in _value_assertions(path, fact.value):
+                local[address].add(marker)
+            for address, markers in local.items():
+                self.markers[address].add(frozenset(markers))
+
+    def conflicts(self) -> bool:
+        incompatible = any(len(values) > 1 for values in self.markers.values())
+        absent_ancestor = any(path[:length] in self.absent for path in self.markers for length in range(len(path) + 1))
+        return incompatible or absent_ancestor
+
+
+def _window_key(source: DescriptionProvenanceModel) -> str:
+    return canonical_json_digest(
+        {
+            "time": source.recorded_at,
+            "window": source.window_ref,
+            "operation": source.operation_ref.model_dump(mode="json") if source.operation_ref else None,
+            "configuration": source.configuration_ref.model_dump(mode="json") if source.configuration_ref else None,
+        }
+    )
 
 
 def assertion_conflict(description: TypedRealizationDescriptionModel) -> str | None:
     """Return a conflict category; separate windows never prove a common state."""
-    windows = defaultdict(lambda: defaultdict(set))
-    absent = defaultdict(set)
+    if any(fact.state == "contradictory" for fact in description.facts):
+        return "contradictory"
+    windows: dict[str, _WindowAssertions] = {}
     for fact in description.facts:
-        if fact.state == "contradictory":
-            return "contradictory"
-        if fact.state not in {"known", "known-absent"}:
-            continue
-        source = fact.provenance or description.provenance
-        window = canonical_json_digest(
-            {
-                "time": source.recorded_at,
-                "window": source.window_ref,
-                "operation": source.operation_ref.model_dump(mode="json") if source.operation_ref else None,
-                "configuration": source.configuration_ref.model_dump(mode="json") if source.configuration_ref else None,
-            }
-        )
-        assertions = windows[window]
-        path = pointer_tokens(fact.subject)
-        if fact.state == "known-absent":
-            absent[window].add(path)
-        else:
-            # Each fact can assert multiple compatible markers at one node.
-            local = defaultdict(set)
-            for address, marker in _value_assertions(path, fact.value):
-                local[address].add(marker)
-            for address, markers in local.items():
-                assertions[address].add(frozenset(markers))
-    for window, assertions in windows.items():
-        if any(len(values) > 1 for values in assertions.values()):
-            return "contradictory"
-        if any(path[:length] in absent[window] for path in assertions for length in range(len(path) + 1)):
-            return "contradictory"
+        if fact.state in {"known", "known-absent"}:
+            window = _window_key(fact.provenance or description.provenance)
+            windows.setdefault(window, _WindowAssertions()).add(fact)
+    if any(window.conflicts() for window in windows.values()):
+        return "contradictory"
     return "different-windows" if len(windows) > 1 else None

--- a/implementations/python/packages/raes_contracts/contracts/__init__.py
+++ b/implementations/python/packages/raes_contracts/contracts/__init__.py
@@ -389,6 +389,12 @@ from .random_stream import (
     StreamAddressModel,
     TrialCoordinateModel,
 )
+from .realization_descriptions import (
+    DescriptionCoverageModel,
+    DescriptionFactModel,
+    DescriptionProvenanceModel,
+    TypedRealizationDescriptionModel,
+)
 from .realization_plans import (
     EvaluationPlanModel,
     ObservedOperatingSystemIdentityModel,

--- a/implementations/python/packages/raes_contracts/contracts/_exports.py
+++ b/implementations/python/packages/raes_contracts/contracts/_exports.py
@@ -3,6 +3,10 @@
 from ._candidate_synthesis_exports import CANDIDATE_SYNTHESIS_EXPORTS
 
 PUBLIC_EXPORTS = [
+    "DescriptionCoverageModel",
+    "DescriptionFactModel",
+    "DescriptionProvenanceModel",
+    "TypedRealizationDescriptionModel",
     "ACTIVITYSTREAMS_ACTIVITY_TYPES_SOURCE_SCHEMA_VERSION",
     "ActivityStreamsActivityTypeSourceTermModel",
     "ActivityStreamsActivityTypesSourceModel",

--- a/implementations/python/packages/raes_contracts/contracts/experiment_evidence.py
+++ b/implementations/python/packages/raes_contracts/contracts/experiment_evidence.py
@@ -27,6 +27,7 @@ from .experiment_references import (
     ExperimentReferenceModel,
     ExperimentTaskReferenceModel,
 )
+from .realization_descriptions import TypedRealizationDescriptionModel, validate_description_host
 from .schema_invariants import (
     _add_raes_invariant,
     _add_raes_plane,
@@ -56,10 +57,18 @@ class ExperimentEvidenceRecordModel(ContractModel):
     redaction_state: Literal["none", "redacted", "withheld"]
     redaction_policy: NonEmptyString | None = None
     provenance_refs: list[ExperimentReferenceModel] = Field(default_factory=list)
+    typed_description: TypedRealizationDescriptionModel | None = None
 
     @model_validator(mode="after")
     def _validate_evidence_record(self) -> ExperimentEvidenceRecordModel:
+        validate_description_host(self.typed_description, "experiment-evidence-record-v1")
         _parse_rfc3339_datetime("captured_at", self.captured_at)
+        if (
+            self.redaction_state == "withheld"
+            and self.typed_description is not None
+            and any(fact.state == "known" for fact in self.typed_description.facts)
+        ):
+            raise ValueError("withheld evidence cannot carry known descriptive values")
         if self.redaction_state != "none" and self.raw_content.loss_disclosure is None:
             raise ValueError("redacted or withheld evidence records must include raw_content.loss_disclosure")
         if (self.redaction_state == "none") != (self.redaction_policy is None):
@@ -74,6 +83,15 @@ class ExperimentEvidenceRecordModel(ContractModel):
     ) -> JsonSchemaValue:
         json_schema = handler(core_schema)
         json_schema = handler.resolve_ref_schema(json_schema)
+        _add_raes_invariant(
+            json_schema,
+            "evidence-description-nonauthoritative",
+            "Typed descriptions preserve bounded supplied values, explicit knowledge, coverage and source identities; "
+            "they do not carry author closure or establish capture satisfaction. Withheld evidence carries no known values. "
+            "Profile owners bind to the fact scope and capture carrier; nested profile basis and evidence join fact provenance.",
+            validator="raes_contracts.contracts.ExperimentEvidenceRecordModel.model_validate",
+            inputs=[{"contract_id": "experiment-evidence-record-v1", "instance_path": "#"}],
+        )
         _add_raes_invariant(
             json_schema,
             "evidence-record-raw-content-present",
@@ -257,9 +275,11 @@ class ExperimentRealizedFormDisclosureModel(ContractModel):
     realized_value_summary: NonEmptyString | None = None
     disclosure: NonEmptyString
     evidence_refs: list[ExperimentEvidenceRecordReferenceModel] = Field(default_factory=list)
+    typed_description: TypedRealizationDescriptionModel | None = None
 
     @model_validator(mode="after")
     def _validate_realized_form_disclosure(self) -> ExperimentRealizedFormDisclosureModel:
+        validate_description_host(self.typed_description, "experiment-run-v1")
         if self.realized_ref is None and self.realized_value_summary is None:
             raise ValueError("realized form disclosures must include realized_ref or realized_value_summary")
         if self.basis == "processor-realized" and self.realized_by_ref.ref_kind != "processor":
@@ -320,6 +340,15 @@ class ExperimentRealizedFormDisclosureModel(ContractModel):
             validator=(
                 "raes_contracts.contracts.ExperimentRealizedFormDisclosureModel._validate_realized_form_disclosure"
             ),
+            inputs=[{"contract_id": "experiment-run-v1", "instance_path": "#/realized_form_disclosures"}],
+        )
+        _add_raes_invariant(
+            json_schema,
+            "realized-description-nonauthoritative",
+            "Typed descriptions preserve explicit knowledge, bounded recursive values and coverage separately from "
+            "author authority, with versioned sources and exact extension coordinates. Profile owners bind to the fact scope "
+            "and realization-description carrier; nested profile basis and evidence join fact provenance.",
+            validator="raes_contracts.contracts.ExperimentRealizedFormDisclosureModel.model_validate",
             inputs=[{"contract_id": "experiment-run-v1", "instance_path": "#/realized_form_disclosures"}],
         )
         return json_schema

--- a/implementations/python/packages/raes_contracts/contracts/experiment_evidence.py
+++ b/implementations/python/packages/raes_contracts/contracts/experiment_evidence.py
@@ -87,8 +87,10 @@ class ExperimentEvidenceRecordModel(ContractModel):
             json_schema,
             "evidence-description-nonauthoritative",
             "Typed descriptions preserve bounded supplied values, explicit knowledge, coverage and source identities; "
-            "they do not carry author closure or establish capture satisfaction. Withheld evidence carries no known values. "
-            "Profile owners bind to the fact scope and capture carrier; nested profile basis and evidence join fact provenance.",
+            "they do not carry author closure or establish capture satisfaction. Withheld evidence "
+            "carries no known values. "
+            "Profile owners bind to the fact scope and capture carrier; nested profile basis and evidence "
+            "join fact provenance.",
             validator="raes_contracts.contracts.ExperimentEvidenceRecordModel.model_validate",
             inputs=[{"contract_id": "experiment-evidence-record-v1", "instance_path": "#"}],
         )
@@ -346,7 +348,8 @@ class ExperimentRealizedFormDisclosureModel(ContractModel):
             json_schema,
             "realized-description-nonauthoritative",
             "Typed descriptions preserve explicit knowledge, bounded recursive values and coverage separately from "
-            "author authority, with versioned sources and exact extension coordinates. Profile owners bind to the fact scope "
+            "author authority, with versioned sources and exact extension coordinates. Profile owners "
+            "bind to the fact scope "
             "and realization-description carrier; nested profile basis and evidence join fact provenance.",
             validator="raes_contracts.contracts.ExperimentRealizedFormDisclosureModel.model_validate",
             inputs=[{"contract_id": "experiment-run-v1", "instance_path": "#/realized_form_disclosures"}],

--- a/implementations/python/packages/raes_contracts/contracts/realization_descriptions.py
+++ b/implementations/python/packages/raes_contracts/contracts/realization_descriptions.py
@@ -1,0 +1,244 @@
+"""Non-authoritative partial descriptions carried by existing lifecycle contracts."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import ConfigDict, Field, model_validator
+
+from ..canonical import canonical_json_digest
+from ..domain_profiles import DomainProfileBindingBasis, DomainProfileBindingModel, DomainProfileBindingUse
+from ..observation_demand import ObservationBasis
+from ..realization_structure import (
+    RealizationKeyedCollectionConstraint,
+    RealizationLiteral,
+    RealizationOrigin,
+    RealizationPresence,
+    RealizationRecordConstraint,
+    RealizationSequenceConstraint,
+    RecursiveRealizationStructure,
+    semantic_address_contains,
+    validate_realization_value,
+)
+from .base import ContractModel, NonEmptyString, Rfc3339DateTimeString, _parse_rfc3339_datetime
+from .experiment_references import ExperimentReferenceModel
+
+DescriptionPointer = Annotated[str, Field(pattern=r"^(?:/(?:[^~/]|~[01])*)*$", max_length=4096)]
+
+
+class DescriptionModel(ContractModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _bound_input(cls, value: object) -> object:
+        if not validate_realization_value(value, python_carriers=True).conformant:
+            raise ValueError("description exceeds the supported finite value bounds")
+        return value
+
+
+class DescriptionProvenanceModel(DescriptionModel):
+    """Actual source and basis, inherited unless a fact explicitly overrides it."""
+
+    observer_ref: ExperimentReferenceModel
+    recorded_at: Rfc3339DateTimeString
+    basis: ObservationBasis
+    window_ref: NonEmptyString
+    operation_ref: ExperimentReferenceModel | None = None
+    configuration_ref: ExperimentReferenceModel | None = None
+    evidence_refs: tuple[ExperimentReferenceModel, ...] = Field(default=(), max_length=256)
+
+    @model_validator(mode="after")
+    def _validate_provenance(self) -> DescriptionProvenanceModel:
+        _parse_rfc3339_datetime("recorded_at", self.recorded_at)
+        if not self.observer_ref.ref_version:
+            raise ValueError("description observer requires an explicit version")
+        if (
+            self.basis in {ObservationBasis.OBSERVED, ObservationBasis.INDEPENDENTLY_VERIFIED}
+            and not self.evidence_refs
+        ):
+            raise ValueError("observed description basis requires evidence references")
+        return self
+
+
+class DescriptionFactModel(DescriptionModel):
+    """One assertion; different sources at the same subject remain separate facts."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        json_schema_extra={
+            "allOf": [
+                {
+                    "if": {"properties": {"state": {"const": "known"}}, "required": ["state"]},
+                    "then": {"required": ["value"], "properties": {"value": {"not": {"type": "null"}}}},
+                    "else": {"properties": {"value": {"type": "null"}, "profile_bindings": {"maxItems": 0}}},
+                }
+            ]
+        },
+    )
+
+    fact_id: NonEmptyString
+    subject: DescriptionPointer
+    component_ref: NonEmptyString | None = None
+    state: Literal["known", "not-observed", "known-absent", "withheld", "contradictory", "not-applicable"]
+    value: RecursiveRealizationStructure | None = None
+    provenance: DescriptionProvenanceModel | None = None
+    profile_bindings: tuple[DomainProfileBindingModel, ...] = Field(default=(), max_length=256)
+    limitations: tuple[NonEmptyString, ...] = Field(default=(), max_length=256)
+
+    @model_validator(mode="after")
+    def _validate_state(self) -> DescriptionFactModel:
+        if self.state != "known" and (self.value is not None or self.profile_bindings):
+            raise ValueError("nonknown facts cannot carry values or profile bindings")
+        if self.state == "known" and self.value is None:
+            raise ValueError("known facts require an explicit typed value")
+        if self.value is not None:
+            _validate_descriptive_value(self.value)
+        for binding in self.profile_bindings:
+            _validate_descriptive_binding(binding, self.subject)
+        return self
+
+
+class DescriptionCoverageModel(DescriptionModel):
+    """Enumeration coverage in a named universe; never author collection closure."""
+
+    subject: DescriptionPointer
+    kind: Literal["field", "collection"]
+    universe: NonEmptyString
+    profile: NonEmptyString
+    status: Literal["partial", "complete", "not-observed", "withheld"]
+    recursive: bool = False
+    fact_ids: tuple[NonEmptyString, ...] = Field(default=(), max_length=4096)
+    provenance: DescriptionProvenanceModel | None = None
+    limitations: tuple[NonEmptyString, ...] = Field(default=(), max_length=256)
+
+
+class TypedRealizationDescriptionModel(DescriptionModel):
+    """Versioned descriptive content, separate from its original author request."""
+
+    schema_version: Literal["realization-description/v1"]
+    description_id: NonEmptyString
+    description_version: NonEmptyString
+    semantic_profile: NonEmptyString
+    authored_ref: ExperimentReferenceModel
+    provenance: DescriptionProvenanceModel
+    facts: tuple[DescriptionFactModel, ...] = Field(default=(), max_length=4096)
+    coverage: tuple[DescriptionCoverageModel, ...] = Field(default=(), max_length=4096)
+    limitations: tuple[NonEmptyString, ...] = Field(default=(), max_length=256)
+
+    @model_validator(mode="after")
+    def _validate_description(self) -> TypedRealizationDescriptionModel:
+        if not self.authored_ref.ref_version or not self.authored_ref.ref_digest:
+            raise ValueError("original authored reference requires version and digest")
+        facts = {fact.fact_id: fact for fact in self.facts}
+        if len(facts) != len(self.facts):
+            raise ValueError("description fact ids must be unique")
+        for fact in self.facts:
+            provenance = fact.provenance or self.provenance
+            for binding in iter_description_bindings(fact.profile_bindings):
+                _validate_binding_provenance(binding, provenance)
+        for coverage in self.coverage:
+            if len(coverage.fact_ids) != len(set(coverage.fact_ids)):
+                raise ValueError("coverage fact ids must be unique")
+            if any(
+                fact_id not in facts or not semantic_address_contains(coverage.subject, facts[fact_id].subject)
+                for fact_id in coverage.fact_ids
+            ):
+                raise ValueError("coverage must reference facts inside its named scope")
+        return self
+
+
+def _validate_descriptive_value(value: RecursiveRealizationStructure) -> None:
+    if value.origin not in {RealizationOrigin.BACKEND, RealizationOrigin.OBSERVATION}:
+        raise ValueError("descriptive values require explicit backend or observation origin")
+    if value.presence is not RealizationPresence.REQUIRED:
+        raise ValueError("descriptive values cannot carry author presence constraints")
+    if isinstance(value, RealizationLiteral):
+        return
+    if isinstance(value, RealizationRecordConstraint):
+        children = tuple(value.fields.values())
+    elif isinstance(value, RealizationSequenceConstraint):
+        children = value.items
+    elif isinstance(value, RealizationKeyedCollectionConstraint):
+        children = tuple(member.constraint for member in value.members)
+        if value.aliases:
+            raise ValueError("descriptions retain actual identities, not comparison aliases")
+        for member in value.members:
+            if not isinstance(member.constraint, RealizationRecordConstraint):
+                raise ValueError("descriptive member identity requires a record value")
+            actual = tuple(member.constraint.fields.get(name) for name in value.identity_fields)
+            if any(not isinstance(item, RealizationLiteral) for item in actual) or (
+                canonical_json_digest([item.value for item in actual]) != canonical_json_digest(list(member.identity))
+            ):
+                raise ValueError("descriptive member identity must match supplied identity fields")
+    else:
+        raise ValueError("descriptions cannot carry delegated, domain, reference, or conjunction authority")
+    if value.closure.posture.value != "undefined":
+        raise ValueError("description coverage must not be encoded as author closure")
+    if isinstance(value, (RealizationSequenceConstraint, RealizationKeyedCollectionConstraint)) and (
+        value.min_items != 0 or value.max_items != 4096
+    ):
+        raise ValueError("description coverage must not carry author cardinality constraints")
+    for child in children:
+        _validate_descriptive_value(child)
+
+
+_DESCRIPTION_HOST_PHASES = {
+    "experiment-evidence-record-v1": "capture",
+    "experiment-run-v1": "realization-description",
+}
+
+
+def _validate_descriptive_binding(binding: DomainProfileBindingModel, subject: str, parent=None) -> None:
+    if binding.owner.use not in {DomainProfileBindingUse.TYPED_REPORT, DomainProfileBindingUse.OPAQUE_EXCHANGE}:
+        raise ValueError("description profiles cannot carry author constraints")
+    owner = binding.owner
+    if _DESCRIPTION_HOST_PHASES.get(owner.owning_contract_id) != owner.lifecycle_phase or not semantic_address_contains(
+        subject, owner.canonical_address[1:]
+    ):
+        raise ValueError("description profile owner must match the fact scope and supported lifecycle carrier")
+    if parent is not None and (owner.owning_contract_id, owner.lifecycle_phase) != (
+        parent.owning_contract_id,
+        parent.lifecycle_phase,
+    ):
+        raise ValueError("nested description profile owner must retain its lifecycle carrier")
+    for child in binding.children:
+        _validate_descriptive_binding(child, owner.canonical_address[1:], owner)
+
+
+def iter_description_bindings(bindings):
+    for binding in bindings:
+        yield binding
+        yield from iter_description_bindings(binding.children)
+
+
+def _validate_binding_provenance(binding, provenance) -> None:
+    expected = {
+        ObservationBasis.BACKEND_SELECTED: DomainProfileBindingBasis.BACKEND_SELECTED,
+        ObservationBasis.OBSERVED: DomainProfileBindingBasis.OBSERVED,
+        ObservationBasis.INDEPENDENTLY_VERIFIED: DomainProfileBindingBasis.OBSERVED,
+    }.get(provenance.basis)
+    if binding.provenance.basis is not expected:
+        raise ValueError("description profile basis must match its fact provenance")
+    if not set(binding.provenance.evidence_refs) <= {ref.ref_id for ref in provenance.evidence_refs}:
+        raise ValueError("description profile evidence must join its fact provenance")
+
+
+def validate_description_host(description: TypedRealizationDescriptionModel | None, host: str) -> None:
+    if description is None:
+        return
+    if any(
+        binding.owner.owning_contract_id != host
+        for fact in description.facts
+        for binding in iter_description_bindings(fact.profile_bindings)
+    ):
+        raise ValueError("description profile owner must match the enclosing lifecycle carrier")
+
+
+__all__ = [
+    "DescriptionCoverageModel",
+    "DescriptionFactModel",
+    "DescriptionProvenanceModel",
+    "TypedRealizationDescriptionModel",
+]

--- a/implementations/python/packages/raes_contracts/contracts/realization_descriptions.py
+++ b/implementations/python/packages/raes_contracts/contracts/realization_descriptions.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from typing import Annotated, Literal
 
 from pydantic import ConfigDict, Field, model_validator
 
 from ..canonical import canonical_json_digest
-from ..domain_profiles import DomainProfileBindingBasis, DomainProfileBindingModel, DomainProfileBindingUse
+from ..domain_profiles import (
+    DomainProfileBindingBasis,
+    DomainProfileBindingModel,
+    DomainProfileBindingOwnerModel,
+    DomainProfileBindingUse,
+)
 from ..observation_demand import ObservationBasis
 from ..realization_structure import (
     RealizationKeyedCollectionConstraint,
@@ -139,14 +145,20 @@ class TypedRealizationDescriptionModel(DescriptionModel):
             for binding in iter_description_bindings(fact.profile_bindings):
                 _validate_binding_provenance(binding, provenance)
         for coverage in self.coverage:
-            if len(coverage.fact_ids) != len(set(coverage.fact_ids)):
-                raise ValueError("coverage fact ids must be unique")
-            if any(
-                fact_id not in facts or not semantic_address_contains(coverage.subject, facts[fact_id].subject)
-                for fact_id in coverage.fact_ids
-            ):
-                raise ValueError("coverage must reference facts inside its named scope")
+            _validate_coverage_references(coverage, facts)
         return self
+
+
+def _validate_coverage_references(
+    coverage: DescriptionCoverageModel, facts: Mapping[str, DescriptionFactModel]
+) -> None:
+    if len(coverage.fact_ids) != len(set(coverage.fact_ids)):
+        raise ValueError("coverage fact ids must be unique")
+    if any(
+        fact_id not in facts or not semantic_address_contains(coverage.subject, facts[fact_id].subject)
+        for fact_id in coverage.fact_ids
+    ):
+        raise ValueError("coverage must reference facts inside its named scope")
 
 
 def _validate_descriptive_value(value: RecursiveRealizationStructure) -> None:
@@ -156,32 +168,45 @@ def _validate_descriptive_value(value: RecursiveRealizationStructure) -> None:
         raise ValueError("descriptive values cannot carry author presence constraints")
     if isinstance(value, RealizationLiteral):
         return
+    children = _descriptive_children(value)
+    _validate_descriptive_coverage(value)
+    for child in children:
+        _validate_descriptive_value(child)
+
+
+def _descriptive_children(value: RecursiveRealizationStructure) -> tuple[RecursiveRealizationStructure, ...]:
     if isinstance(value, RealizationRecordConstraint):
         children = tuple(value.fields.values())
     elif isinstance(value, RealizationSequenceConstraint):
         children = value.items
     elif isinstance(value, RealizationKeyedCollectionConstraint):
+        _validate_descriptive_identities(value)
         children = tuple(member.constraint for member in value.members)
-        if value.aliases:
-            raise ValueError("descriptions retain actual identities, not comparison aliases")
-        for member in value.members:
-            if not isinstance(member.constraint, RealizationRecordConstraint):
-                raise ValueError("descriptive member identity requires a record value")
-            actual = tuple(member.constraint.fields.get(name) for name in value.identity_fields)
-            if any(not isinstance(item, RealizationLiteral) for item in actual) or (
-                canonical_json_digest([item.value for item in actual]) != canonical_json_digest(list(member.identity))
-            ):
-                raise ValueError("descriptive member identity must match supplied identity fields")
     else:
         raise ValueError("descriptions cannot carry delegated, domain, reference, or conjunction authority")
+    return children
+
+
+def _validate_descriptive_identities(value: RealizationKeyedCollectionConstraint) -> None:
+    if value.aliases:
+        raise ValueError("descriptions retain actual identities, not comparison aliases")
+    for member in value.members:
+        if not isinstance(member.constraint, RealizationRecordConstraint):
+            raise ValueError("descriptive member identity requires a record value")
+        actual = tuple(member.constraint.fields.get(name) for name in value.identity_fields)
+        if any(not isinstance(item, RealizationLiteral) for item in actual) or (
+            canonical_json_digest([item.value for item in actual]) != canonical_json_digest(list(member.identity))
+        ):
+            raise ValueError("descriptive member identity must match supplied identity fields")
+
+
+def _validate_descriptive_coverage(value: RecursiveRealizationStructure) -> None:
     if value.closure.posture.value != "undefined":
         raise ValueError("description coverage must not be encoded as author closure")
     if isinstance(value, (RealizationSequenceConstraint, RealizationKeyedCollectionConstraint)) and (
         value.min_items != 0 or value.max_items != 4096
     ):
         raise ValueError("description coverage must not carry author cardinality constraints")
-    for child in children:
-        _validate_descriptive_value(child)
 
 
 _DESCRIPTION_HOST_PHASES = {
@@ -190,7 +215,9 @@ _DESCRIPTION_HOST_PHASES = {
 }
 
 
-def _validate_descriptive_binding(binding: DomainProfileBindingModel, subject: str, parent=None) -> None:
+def _validate_descriptive_binding(
+    binding: DomainProfileBindingModel, subject: str, parent: DomainProfileBindingOwnerModel | None = None
+) -> None:
     if binding.owner.use not in {DomainProfileBindingUse.TYPED_REPORT, DomainProfileBindingUse.OPAQUE_EXCHANGE}:
         raise ValueError("description profiles cannot carry author constraints")
     owner = binding.owner
@@ -207,13 +234,13 @@ def _validate_descriptive_binding(binding: DomainProfileBindingModel, subject: s
         _validate_descriptive_binding(child, owner.canonical_address[1:], owner)
 
 
-def iter_description_bindings(bindings):
+def iter_description_bindings(bindings: tuple[DomainProfileBindingModel, ...]) -> Iterator[DomainProfileBindingModel]:
     for binding in bindings:
         yield binding
         yield from iter_description_bindings(binding.children)
 
 
-def _validate_binding_provenance(binding, provenance) -> None:
+def _validate_binding_provenance(binding: DomainProfileBindingModel, provenance: DescriptionProvenanceModel) -> None:
     expected = {
         ObservationBasis.BACKEND_SELECTED: DomainProfileBindingBasis.BACKEND_SELECTED,
         ObservationBasis.OBSERVED: DomainProfileBindingBasis.OBSERVED,

--- a/implementations/python/packages/raes_contracts/description_coverage.py
+++ b/implementations/python/packages/raes_contracts/description_coverage.py
@@ -1,7 +1,13 @@
 """One coverage decision for requested reports and author conformance."""
 
+from dataclasses import dataclass
+
 from ._description_assertions import assertion_conflict
-from .contracts.realization_descriptions import DescriptionCoverageModel, TypedRealizationDescriptionModel
+from .contracts.realization_descriptions import (
+    DescriptionCoverageModel,
+    DescriptionProvenanceModel,
+    TypedRealizationDescriptionModel,
+)
 from .realization_structure import semantic_address_contains
 
 
@@ -9,49 +15,62 @@ class DescriptionCoverageUnsatisfied(ValueError):
     """A valid partial report cannot satisfy the requested complete coverage."""
 
 
-def coverage_matches(
-    description: TypedRealizationDescriptionModel,
-    coverage: DescriptionCoverageModel,
-    *,
-    scope: str,
-    kind: str,
-    profile: str | None = None,
-    universe: str | None = None,
-    exclusions: tuple[str, ...] = (),
-    complete: bool = False,
-) -> bool:
-    """Retain only claims inside a boundary; complete claims must match it exactly."""
-    if not semantic_address_contains(scope, coverage.subject) or coverage.kind != kind:
-        return False
-    if any(
-        semantic_address_contains(excluded, coverage.subject) or semantic_address_contains(coverage.subject, excluded)
-        for excluded in exclusions
-    ):
-        return False
-    if (profile is not None and coverage.profile != profile) or (
-        universe is not None and coverage.universe != universe
-    ):
-        return False
-    if not complete:
-        return True
+@dataclass(frozen=True)
+class DescriptionCoverageScope:
+    scope: str
+    kind: str
+    profile: str | None = None
+    universe: str | None = None
+    exclusions: tuple[str, ...] = ()
+
+
+def _matches_scope(coverage: DescriptionCoverageModel, requested: DescriptionCoverageScope) -> bool:
+    inside = semantic_address_contains(requested.scope, coverage.subject) and coverage.kind == requested.kind
+    excluded = any(
+        semantic_address_contains(scope, coverage.subject) or semantic_address_contains(coverage.subject, scope)
+        for scope in requested.exclusions
+    )
+    profile_matches = requested.profile is None or coverage.profile == requested.profile
+    universe_matches = requested.universe is None or coverage.universe == requested.universe
+    return inside and not excluded and profile_matches and universe_matches
+
+
+def _complete_facts(description: TypedRealizationDescriptionModel, coverage: DescriptionCoverageModel) -> bool:
     return (
-        coverage.subject == scope
-        and coverage.status == "complete"
-        and coverage.recursive
-        and not coverage.limitations
-        and not description.limitations
+        bool(description.facts)
         and set(coverage.fact_ids) == {fact.fact_id for fact in description.facts}
-        and bool(description.facts)
         and all(fact.state in {"known", "known-absent"} and not fact.limitations for fact in description.facts)
-        and all(
-            same_window(fact.provenance or description.provenance, coverage.provenance or description.provenance)
-            for fact in description.facts
-        )
+        and _facts_share_window(description, coverage)
         and assertion_conflict(description) is None
     )
 
 
-def same_window(left, right) -> bool:
+def _facts_share_window(description: TypedRealizationDescriptionModel, coverage: DescriptionCoverageModel) -> bool:
+    source = coverage.provenance or description.provenance
+    return all(same_window(fact.provenance or description.provenance, source) for fact in description.facts)
+
+
+def coverage_matches(
+    description: TypedRealizationDescriptionModel,
+    coverage: DescriptionCoverageModel,
+    requested: DescriptionCoverageScope,
+    *,
+    complete: bool = False,
+) -> bool:
+    """Retain only claims inside a boundary; complete claims must match it exactly."""
+    if not _matches_scope(coverage, requested):
+        return False
+    return not complete or (
+        coverage.subject == requested.scope
+        and coverage.status == "complete"
+        and coverage.recursive
+        and not coverage.limitations
+        and not description.limitations
+        and _complete_facts(description, coverage)
+    )
+
+
+def same_window(left: DescriptionProvenanceModel, right: DescriptionProvenanceModel) -> bool:
     return (left.recorded_at, left.window_ref, left.operation_ref, left.configuration_ref, left.basis) == (
         right.recorded_at,
         right.window_ref,

--- a/implementations/python/packages/raes_contracts/description_coverage.py
+++ b/implementations/python/packages/raes_contracts/description_coverage.py
@@ -1,0 +1,61 @@
+"""One coverage decision for requested reports and author conformance."""
+
+from ._description_assertions import assertion_conflict
+from .contracts.realization_descriptions import DescriptionCoverageModel, TypedRealizationDescriptionModel
+from .realization_structure import semantic_address_contains
+
+
+class DescriptionCoverageUnsatisfied(ValueError):
+    """A valid partial report cannot satisfy the requested complete coverage."""
+
+
+def coverage_matches(
+    description: TypedRealizationDescriptionModel,
+    coverage: DescriptionCoverageModel,
+    *,
+    scope: str,
+    kind: str,
+    profile: str | None = None,
+    universe: str | None = None,
+    exclusions: tuple[str, ...] = (),
+    complete: bool = False,
+) -> bool:
+    """Retain only claims inside a boundary; complete claims must match it exactly."""
+    if not semantic_address_contains(scope, coverage.subject) or coverage.kind != kind:
+        return False
+    if any(
+        semantic_address_contains(excluded, coverage.subject) or semantic_address_contains(coverage.subject, excluded)
+        for excluded in exclusions
+    ):
+        return False
+    if (profile is not None and coverage.profile != profile) or (
+        universe is not None and coverage.universe != universe
+    ):
+        return False
+    if not complete:
+        return True
+    return (
+        coverage.subject == scope
+        and coverage.status == "complete"
+        and coverage.recursive
+        and not coverage.limitations
+        and not description.limitations
+        and set(coverage.fact_ids) == {fact.fact_id for fact in description.facts}
+        and bool(description.facts)
+        and all(fact.state in {"known", "known-absent"} and not fact.limitations for fact in description.facts)
+        and all(
+            same_window(fact.provenance or description.provenance, coverage.provenance or description.provenance)
+            for fact in description.facts
+        )
+        and assertion_conflict(description) is None
+    )
+
+
+def same_window(left, right) -> bool:
+    return (left.recorded_at, left.window_ref, left.operation_ref, left.configuration_ref, left.basis) == (
+        right.recorded_at,
+        right.window_ref,
+        right.operation_ref,
+        right.configuration_ref,
+        right.basis,
+    )

--- a/implementations/python/packages/raes_contracts/description_projection.py
+++ b/implementations/python/packages/raes_contracts/description_projection.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 from ._description_assertions import assertion_conflict
 from .canonical import canonical_json_digest
 from .contracts.realization_descriptions import DescriptionFactModel, TypedRealizationDescriptionModel
-from .description_coverage import coverage_matches
+from .description_coverage import DescriptionCoverageScope, coverage_matches
 from .diagnostics import Diagnostic
 from .realization_structure import (
     RealizationConstraintDocument,
@@ -47,16 +49,22 @@ def readmit_description(description: TypedRealizationDescriptionModel) -> TypedR
 def descriptive_value(value: RecursiveRealizationStructure) -> object:
     """Project supplied values only; no deployment model or default participates."""
     if isinstance(value, RealizationLiteral):
-        return value.value
-    if isinstance(value, RealizationRecordConstraint):
-        return {name: descriptive_value(child) for name, child in value.fields.items()}
+        projected = value.value
+    elif isinstance(value, RealizationRecordConstraint):
+        projected = {name: descriptive_value(child) for name, child in value.fields.items()}
+    else:
+        projected = [descriptive_value(child) for child in _descriptive_items(value)]
+    return projected
+
+
+def _descriptive_items(value: RecursiveRealizationStructure) -> tuple[RecursiveRealizationStructure, ...]:
     if isinstance(value, RealizationSequenceConstraint):
-        return [descriptive_value(child) for child in value.items]
+        return value.items
     if isinstance(value, RealizationKeyedCollectionConstraint):
-        return [
-            descriptive_value(member.constraint)
+        return tuple(
+            member.constraint
             for member in sorted(value.members, key=lambda member: canonical_json_digest(list(member.identity)))
-        ]
+        )
     raise ValueError("unsupported descriptive value")
 
 
@@ -72,46 +80,105 @@ def description_conflict(description: TypedRealizationDescriptionModel) -> Reali
 def _bind_author(
     description: TypedRealizationDescriptionModel, authored: RealizationConstraintDocument
 ) -> RealizationRelationResult | None:
+    result = None
     if not validate_realization_value(authored, python_carriers=True).conformant:
-        return description_result("limit-exceeded", "limit-exceeded", "Author constraints exceed the supported bounds.")
-    if description.semantic_profile != authored.semantic_profile:
-        return description_result("unsupported", "profile", "Description and author semantic profiles differ.")
-    if description.authored_ref.ref_digest != canonical_json_digest(authored.model_dump(mode="json")):
-        return description_result(
+        result = description_result(
+            "limit-exceeded", "limit-exceeded", "Author constraints exceed the supported bounds."
+        )
+    elif description.semantic_profile != authored.semantic_profile:
+        result = description_result("unsupported", "profile", "Description and author semantic profiles differ.")
+    elif description.authored_ref.ref_digest != canonical_json_digest(authored.model_dump(mode="json")):
+        result = description_result(
             "invalid", "author-binding", "The description names a different original author artifact."
         )
+    return result
+
+
+def _extra_scope_failure(
+    authored: RealizationConstraintDocument,
+    rule: RealizationRecordConstraint,
+    tokens: tuple[str, ...],
+    traversed: tuple[str, ...],
+) -> RealizationRelationResult | None:
+    for count in range(len(traversed), len(tokens)):
+        closure = closure_for(authored, rule.closure, tokens[:count])
+        if closure is None or closure.posture.value != "open":
+            return description_result(
+                "nonconformant", "closed-scope", "A supplied fact is outside the closed author scope."
+            )
     return None
 
 
-def _rule_at(authored: RealizationConstraintDocument, subject: str):
-    rule = authored.root
-    traversed = ()
-    for token in pointer_tokens(subject):
+def _rule_at(
+    authored: RealizationConstraintDocument, subject: str
+) -> tuple[RecursiveRealizationStructure | None, RealizationRelationResult | None]:
+    rule: RecursiveRealizationStructure | None = authored.root
+    traversed: tuple[str, ...] = ()
+    failure = None
+    tokens = pointer_tokens(subject)
+    for token in tokens:
         if rule.presence is RealizationPresence.FORBIDDEN:
-            return rule, description_result(
+            failure = description_result(
                 "nonconformant", "forbidden", "A supplied fact is inside a forbidden author scope."
             )
+            break
         if not isinstance(rule, RealizationRecordConstraint):
-            return None, description_result(
+            rule = None
+            failure = description_result(
                 "unsupported", "projection", "Partial projection through this author structure is unsupported."
             )
+            break
         if token not in rule.fields:
-            closure = closure_for(authored, rule.closure, traversed)
-            if closure is None or closure.posture.value != "open":
-                return None, description_result(
-                    "nonconformant", "closed-scope", "A supplied fact is outside the closed author scope."
-                )
-            # Additional descendants remain subject to any explicit lexical scopes.
-            for count in range(len(traversed) + 1, len(pointer_tokens(subject))):
-                inherited = closure_for(authored, rule.closure, pointer_tokens(subject)[:count])
-                if inherited is None or inherited.posture.value != "open":
-                    return None, description_result(
-                        "nonconformant", "closed-scope", "A supplied fact is outside the closed author scope."
-                    )
-            return None, None
+            failure = _extra_scope_failure(authored, rule, tokens, traversed)
+            rule = None
+            break
         rule = rule.fields[token]
         traversed += (token,)
-    return rule, None
+    return rule, failure
+
+
+def _literal_violation(
+    rule: RecursiveRealizationStructure, literal: RealizationLiteral, authored: RealizationConstraintDocument
+) -> RealizationRelationResult | None:
+    if isinstance(
+        rule, (RealizationRecordConstraint, RealizationKeyedCollectionConstraint, RealizationSequenceConstraint)
+    ):
+        return description_result(
+            "nonconformant", "value", "A supplied scalar contradicts the authored structured value."
+        )
+    result = evaluate_realization_constraint(authored.model_copy(update={"root": rule, "scopes": ()}), literal.value)
+    return None if result.conformant else result
+
+
+def _resolved_fact_violation(
+    fact: DescriptionFactModel, rule: RecursiveRealizationStructure | None, authored: RealizationConstraintDocument
+) -> RealizationRelationResult | None:
+    result = None
+    if rule is None:
+        return None
+    if fact.state == "known-absent":
+        if rule.presence is RealizationPresence.REQUIRED:
+            result = description_result(
+                "nonconformant", "known-absent", "A required author field is positively known absent."
+            )
+    elif rule.presence is RealizationPresence.FORBIDDEN:
+        result = description_result(
+            "nonconformant", "forbidden", "A supplied fact contradicts an author absence constraint."
+        )
+    elif isinstance(fact.value, RealizationLiteral):
+        result = _literal_violation(rule, fact.value, authored)
+    return result
+
+
+def _fact_violation(
+    fact: DescriptionFactModel, authored: RealizationConstraintDocument
+) -> RealizationRelationResult | None:
+    if fact.state not in {"known", "known-absent"}:
+        return None
+    rule, failure = _rule_at(authored, fact.subject)
+    if failure is not None:
+        return failure if fact.state == "known" else None
+    return _resolved_fact_violation(fact, rule, authored)
 
 
 def known_fact_violation(
@@ -119,40 +186,12 @@ def known_fact_violation(
 ) -> RealizationRelationResult | None:
     """A supplied scalar can disprove an exact constraint even in a partial report."""
     for fact in _comparison_facts(description.facts):
-        if fact.state not in {"known", "known-absent"}:
-            continue
-        rule, failure = _rule_at(authored, fact.subject)
-        if failure is not None:
-            if fact.state == "known":
-                return failure
-            continue
-        if rule is not None and fact.state == "known-absent":
-            if rule.presence is RealizationPresence.REQUIRED:
-                return description_result(
-                    "nonconformant", "known-absent", "A required author field is positively known absent."
-                )
-            continue
-        if rule is not None and rule.presence is RealizationPresence.FORBIDDEN:
-            return description_result(
-                "nonconformant", "forbidden", "A supplied fact contradicts an author absence constraint."
-            )
-        if rule is None or not isinstance(fact.value, RealizationLiteral):
-            continue
-        if isinstance(
-            rule, (RealizationRecordConstraint, RealizationKeyedCollectionConstraint, RealizationSequenceConstraint)
-        ):
-            return description_result(
-                "nonconformant", "value", "A supplied scalar contradicts the authored structured value."
-            )
-        result = evaluate_realization_constraint(
-            authored.model_copy(update={"root": rule, "scopes": ()}), fact.value.value
-        )
-        if not result.conformant:
-            return result
+        if violation := _fact_violation(fact, authored):
+            return violation
     return None
 
 
-def _comparison_facts(facts):
+def _comparison_facts(facts: tuple[DescriptionFactModel, ...]) -> Iterator[DescriptionFactModel]:
     for fact in facts:
         if fact.state == "known" and isinstance(fact.value, RealizationRecordConstraint):
             children = tuple(
@@ -208,6 +247,12 @@ def assess_realization_description(
         description = readmit_description(description)
     except ValueError:
         return description_result("invalid", "invalid", "Description failed bounded contract admission.")
+    return _assess_admitted_description(description, authored)
+
+
+def _assess_admitted_description(
+    description: TypedRealizationDescriptionModel, authored: RealizationConstraintDocument
+) -> RealizationRelationResult:
     conflict = description_conflict(description)
     precondition = _bind_author(description, authored) or (
         conflict if conflict and conflict.status.value != "unresolved" else None
@@ -218,29 +263,32 @@ def assess_realization_description(
         return description_result(
             "unsupported", "profile-comparison", "Private profile carriage does not establish comparison support."
         )
-    if violation := known_fact_violation(description, authored):
-        return violation
-    if conflict is not None:
-        return conflict
-    root_closure = closure_for(authored, getattr(authored.root, "closure", authored.default_closure), ())
+    return (
+        known_fact_violation(description, authored) or conflict or _assess_complete_description(description, authored)
+    )
+
+
+def _complete_author_coverage(
+    description: TypedRealizationDescriptionModel, authored: RealizationConstraintDocument
+) -> bool:
+    closure = closure_for(authored, getattr(authored.root, "closure", authored.default_closure), ())
+    if closure is None:
+        return False
     kind = (
         "collection"
         if isinstance(authored.root, (RealizationSequenceConstraint, RealizationKeyedCollectionConstraint))
         else "field"
     )
-    complete = root_closure is not None and any(
-        coverage_matches(
-            description,
-            coverage,
-            scope="",
-            kind=kind,
-            profile=root_closure.profile or authored.semantic_profile,
-            universe=root_closure.universe,
-            complete=True,
-        )
-        for coverage in description.coverage
+    requested = DescriptionCoverageScope(
+        scope="", kind=kind, profile=closure.profile or authored.semantic_profile, universe=closure.universe
     )
-    if not complete:
+    return any(coverage_matches(description, coverage, requested, complete=True) for coverage in description.coverage)
+
+
+def _assess_complete_description(
+    description: TypedRealizationDescriptionModel, authored: RealizationConstraintDocument
+) -> RealizationRelationResult:
+    if not _complete_author_coverage(description, authored):
         return description_result(
             "unresolved", "coverage", "The report does not establish complete coverage of the requested realization."
         )

--- a/implementations/python/packages/raes_contracts/description_projection.py
+++ b/implementations/python/packages/raes_contracts/description_projection.py
@@ -1,0 +1,256 @@
+"""Coverage-aware, conservative projections into the existing realization relation."""
+
+from __future__ import annotations
+
+from ._description_assertions import assertion_conflict
+from .canonical import canonical_json_digest
+from .contracts.realization_descriptions import DescriptionFactModel, TypedRealizationDescriptionModel
+from .description_coverage import coverage_matches
+from .diagnostics import Diagnostic
+from .realization_structure import (
+    RealizationConstraintDocument,
+    RealizationKeyedCollectionConstraint,
+    RealizationLiteral,
+    RealizationPresence,
+    RealizationRecordConstraint,
+    RealizationRelationResult,
+    RealizationRelationStatus,
+    RealizationSequenceConstraint,
+    RecursiveRealizationStructure,
+    evaluate_realization_constraint,
+    validate_realization_value,
+)
+from .realization_structure._common import closure_for, json_equal, pointer, pointer_tokens
+
+
+def description_result(status: str, code: str, message: str) -> RealizationRelationResult:
+    return RealizationRelationResult(
+        RealizationRelationStatus(status),
+        (
+            Diagnostic(
+                code=f"description.{code}",
+                domain="realization",
+                address="",
+                message=message,
+            ),
+        ),
+    )
+
+
+def readmit_description(description: TypedRealizationDescriptionModel) -> TypedRealizationDescriptionModel:
+    """Bound mutable nested inputs before serialization and return an isolated copy."""
+    if not validate_realization_value(description, python_carriers=True).conformant:
+        raise ValueError("description exceeds the supported finite value bounds")
+    return TypedRealizationDescriptionModel.model_validate(description.model_dump(mode="json"))
+
+
+def descriptive_value(value: RecursiveRealizationStructure) -> object:
+    """Project supplied values only; no deployment model or default participates."""
+    if isinstance(value, RealizationLiteral):
+        return value.value
+    if isinstance(value, RealizationRecordConstraint):
+        return {name: descriptive_value(child) for name, child in value.fields.items()}
+    if isinstance(value, RealizationSequenceConstraint):
+        return [descriptive_value(child) for child in value.items]
+    if isinstance(value, RealizationKeyedCollectionConstraint):
+        return [
+            descriptive_value(member.constraint)
+            for member in sorted(value.members, key=lambda member: canonical_json_digest(list(member.identity)))
+        ]
+    raise ValueError("unsupported descriptive value")
+
+
+def description_conflict(description: TypedRealizationDescriptionModel) -> RealizationRelationResult | None:
+    conflict = assertion_conflict(description)
+    if conflict == "contradictory":
+        return description_result("invalid", conflict, "Comparable assertions disagree about one subject.")
+    if conflict:
+        return description_result("unresolved", conflict, "Assertions require an explicit common observation window.")
+    return None
+
+
+def _bind_author(
+    description: TypedRealizationDescriptionModel, authored: RealizationConstraintDocument
+) -> RealizationRelationResult | None:
+    if not validate_realization_value(authored, python_carriers=True).conformant:
+        return description_result("limit-exceeded", "limit-exceeded", "Author constraints exceed the supported bounds.")
+    if description.semantic_profile != authored.semantic_profile:
+        return description_result("unsupported", "profile", "Description and author semantic profiles differ.")
+    if description.authored_ref.ref_digest != canonical_json_digest(authored.model_dump(mode="json")):
+        return description_result(
+            "invalid", "author-binding", "The description names a different original author artifact."
+        )
+    return None
+
+
+def _rule_at(authored: RealizationConstraintDocument, subject: str):
+    rule = authored.root
+    traversed = ()
+    for token in pointer_tokens(subject):
+        if rule.presence is RealizationPresence.FORBIDDEN:
+            return rule, description_result(
+                "nonconformant", "forbidden", "A supplied fact is inside a forbidden author scope."
+            )
+        if not isinstance(rule, RealizationRecordConstraint):
+            return None, description_result(
+                "unsupported", "projection", "Partial projection through this author structure is unsupported."
+            )
+        if token not in rule.fields:
+            closure = closure_for(authored, rule.closure, traversed)
+            if closure is None or closure.posture.value != "open":
+                return None, description_result(
+                    "nonconformant", "closed-scope", "A supplied fact is outside the closed author scope."
+                )
+            # Additional descendants remain subject to any explicit lexical scopes.
+            for count in range(len(traversed) + 1, len(pointer_tokens(subject))):
+                inherited = closure_for(authored, rule.closure, pointer_tokens(subject)[:count])
+                if inherited is None or inherited.posture.value != "open":
+                    return None, description_result(
+                        "nonconformant", "closed-scope", "A supplied fact is outside the closed author scope."
+                    )
+            return None, None
+        rule = rule.fields[token]
+        traversed += (token,)
+    return rule, None
+
+
+def known_fact_violation(
+    description: TypedRealizationDescriptionModel, authored: RealizationConstraintDocument
+) -> RealizationRelationResult | None:
+    """A supplied scalar can disprove an exact constraint even in a partial report."""
+    for fact in _comparison_facts(description.facts):
+        if fact.state not in {"known", "known-absent"}:
+            continue
+        rule, failure = _rule_at(authored, fact.subject)
+        if failure is not None:
+            if fact.state == "known":
+                return failure
+            continue
+        if rule is not None and fact.state == "known-absent":
+            if rule.presence is RealizationPresence.REQUIRED:
+                return description_result(
+                    "nonconformant", "known-absent", "A required author field is positively known absent."
+                )
+            continue
+        if rule is not None and rule.presence is RealizationPresence.FORBIDDEN:
+            return description_result(
+                "nonconformant", "forbidden", "A supplied fact contradicts an author absence constraint."
+            )
+        if rule is None or not isinstance(fact.value, RealizationLiteral):
+            continue
+        if isinstance(
+            rule, (RealizationRecordConstraint, RealizationKeyedCollectionConstraint, RealizationSequenceConstraint)
+        ):
+            return description_result(
+                "nonconformant", "value", "A supplied scalar contradicts the authored structured value."
+            )
+        result = evaluate_realization_constraint(
+            authored.model_copy(update={"root": rule, "scopes": ()}), fact.value.value
+        )
+        if not result.conformant:
+            return result
+    return None
+
+
+def _comparison_facts(facts):
+    for fact in facts:
+        if fact.state == "known" and isinstance(fact.value, RealizationRecordConstraint):
+            children = tuple(
+                fact.model_copy(
+                    update={
+                        "subject": pointer((*pointer_tokens(fact.subject), key)),
+                        "value": value,
+                    }
+                )
+                for key, value in fact.value.fields.items()
+            )
+            yield from _comparison_facts(children)
+        else:
+            yield fact
+
+
+def description_values(facts: tuple[DescriptionFactModel, ...]) -> object:
+    """Assemble explicit disjoint record facts; never fill missing descendants."""
+    root: dict[str, object] = {}
+    supplied = {}
+    for fact in facts:
+        if fact.state != "known":
+            continue
+        value = descriptive_value(fact.value)
+        if fact.subject in supplied and not json_equal(supplied[fact.subject], value):
+            raise ValueError("overlapping description facts require explicit reconciliation")
+        supplied[fact.subject] = value
+    paths = sorted(pointer_tokens(subject) for subject in supplied)
+    if any(b[: len(a)] == a for a, b in zip(paths, paths[1:], strict=False)):
+        raise ValueError("overlapping description fact projections require explicit reconciliation")
+    for fact in facts:
+        if fact.state != "known":
+            continue
+        value = descriptive_value(fact.value)
+        tokens = pointer_tokens(fact.subject)
+        if not tokens:
+            return value
+        current = root
+        for token in tokens[:-1]:
+            current = current.setdefault(token, {})
+        current[tokens[-1]] = value
+    return root
+
+
+def assess_realization_description(
+    description: TypedRealizationDescriptionModel, authored: RealizationConstraintDocument
+) -> RealizationRelationResult:
+    """Assess facts at their actual coverage; a schema pass never establishes delivery."""
+    bounded = validate_realization_value(description, python_carriers=True)
+    if not bounded.conformant:
+        return bounded
+    try:
+        description = readmit_description(description)
+    except ValueError:
+        return description_result("invalid", "invalid", "Description failed bounded contract admission.")
+    conflict = description_conflict(description)
+    precondition = _bind_author(description, authored) or (
+        conflict if conflict and conflict.status.value != "unresolved" else None
+    )
+    if precondition is not None:
+        return precondition
+    if any(fact.profile_bindings for fact in description.facts):
+        return description_result(
+            "unsupported", "profile-comparison", "Private profile carriage does not establish comparison support."
+        )
+    if violation := known_fact_violation(description, authored):
+        return violation
+    if conflict is not None:
+        return conflict
+    root_closure = closure_for(authored, getattr(authored.root, "closure", authored.default_closure), ())
+    kind = (
+        "collection"
+        if isinstance(authored.root, (RealizationSequenceConstraint, RealizationKeyedCollectionConstraint))
+        else "field"
+    )
+    complete = root_closure is not None and any(
+        coverage_matches(
+            description,
+            coverage,
+            scope="",
+            kind=kind,
+            profile=root_closure.profile or authored.semantic_profile,
+            universe=root_closure.universe,
+            complete=True,
+        )
+        for coverage in description.coverage
+    )
+    if not complete:
+        return description_result(
+            "unresolved", "coverage", "The report does not establish complete coverage of the requested realization."
+        )
+    try:
+        values = description_values(description.facts)
+    except ValueError:
+        return description_result(
+            "unsupported", "overlapping-projection", "Overlapping facts require an explicit reconciled projection."
+        )
+    return evaluate_realization_constraint(authored, values)
+
+
+__all__ = ["assess_realization_description"]

--- a/implementations/python/packages/raes_contracts/description_promotion.py
+++ b/implementations/python/packages/raes_contracts/description_promotion.py
@@ -1,0 +1,164 @@
+"""Explicit pure promotion; callers retain ownership of author mutation admission."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .canonical import canonical_json_digest
+from .contracts.artifact_transformations import (
+    ArtifactTransformationCheckModel,
+    ArtifactTransformationPreservationModel,
+    ArtifactTransformationReportModel,
+)
+from .contracts.base import _parse_rfc3339_datetime
+from .contracts.experiment_references import ExperimentReferenceModel
+from .contracts.realization_descriptions import TypedRealizationDescriptionModel
+from .description_projection import (
+    _bind_author,
+    description_conflict,
+    description_values,
+    known_fact_violation,
+    readmit_description,
+)
+from .realization_structure import (
+    RealizationConstraintDocument,
+    RealizationLiteral,
+    compose_realization_constraints,
+    normalize_realization_literal,
+    realization_constraint_refines,
+    semantic_address_contains,
+    validate_realization_value,
+)
+
+
+@dataclass(frozen=True)
+class DescriptionPromotion:
+    constraints: RealizationConstraintDocument
+    selected_fact_ids: tuple[str, ...]
+    source_ref: ExperimentReferenceModel
+    target_ref: ExperimentReferenceModel
+    actor: str
+    decision_id: str
+    decided_at: str
+    transformation: ArtifactTransformationReportModel
+
+
+def promote_description(
+    description: TypedRealizationDescriptionModel,
+    authored: RealizationConstraintDocument,
+    *,
+    fact_ids: tuple[str, ...],
+    actor: str,
+    decision_id: str,
+    decided_at: str,
+    target_id: str,
+    target_version: str,
+) -> DescriptionPromotion:
+    """Conjoin selected known scalar facts with an isolated original constraint.
+
+    This returns a new artifact and decision record. It grants no storage,
+    execution, or authoring permission and performs no external operation.
+    """
+    decision = {
+        "fact_ids": fact_ids,
+        "actor": actor,
+        "decision_id": decision_id,
+        "decided_at": decided_at,
+        "target_id": target_id,
+        "target_version": target_version,
+    }
+    if not validate_realization_value(decision, python_carriers=True).conformant:
+        raise ValueError("promotion decision exceeds the supported bounds")
+    if any(
+        not isinstance(value, str) or not value.strip() for value in (actor, decision_id, target_id, target_version)
+    ):
+        raise ValueError("promotion requires explicit actor, decision and target identities")
+    _parse_rfc3339_datetime("decided_at", decided_at)
+    description = readmit_description(description)
+    if _bind_author(description, authored) is not None:
+        raise ValueError("promotion requires the matching original author artifact")
+    if (target_id, target_version) == (description.authored_ref.ref_id, description.authored_ref.ref_version):
+        raise ValueError("promotion must create a new authored artifact identity")
+    if not fact_ids or len(set(fact_ids)) != len(fact_ids):
+        raise ValueError("promotion requires a nonempty unique selection of fact ids")
+    selected = tuple(fact for fact in description.facts if fact.fact_id in fact_ids)
+    if len(selected) != len(fact_ids) or any(
+        fact.state != "known"
+        or not isinstance(fact.value, RealizationLiteral)
+        or fact.profile_bindings
+        or fact.limitations
+        for fact in selected
+    ):
+        raise ValueError("promotion requires selected known supported scalar facts without limitations")
+    selected_subjects = {fact.subject for fact in selected}
+    competing = description.model_copy(
+        update={
+            "facts": tuple(
+                fact
+                for fact in description.facts
+                if any(
+                    semantic_address_contains(subject, fact.subject) or semantic_address_contains(fact.subject, subject)
+                    for subject in selected_subjects
+                )
+            )
+        }
+    )
+    if description_conflict(competing) is not None or known_fact_violation(competing, authored) is not None:
+        raise ValueError("promotion cannot resolve conflicting assertions or weaken author constraints")
+    values = description_values(selected)
+    normalized = normalize_realization_literal(values, semantic_profile=authored.semantic_profile)
+    if normalized.document is None:
+        raise ValueError("promotion selection could not be normalized within supported bounds")
+    original = RealizationConstraintDocument.model_validate(authored.model_dump(mode="json"))
+    additional = original.model_copy(update={"root": normalized.document.root})
+    composed = compose_realization_constraints(original, additional)
+    if composed.document is None or not realization_constraint_refines(composed.document, original).conformant:
+        raise ValueError("promotion could not establish a conforming refinement")
+    target = composed.document
+    source_digest = canonical_json_digest(description.model_dump(mode="json"))
+    target_digest = canonical_json_digest(target.model_dump(mode="json"))
+    selected_ids = tuple(sorted(fact_ids))
+    policy_digest = canonical_json_digest({**decision, "fact_ids": list(selected_ids)})
+    transformation = ArtifactTransformationReportModel(
+        operation_profile="description-promotion/v1",
+        status="success",
+        artifact_kind="portable-contract",
+        source_profile=description.schema_version,
+        target_profile=target.contract_id,
+        canonicalization_profile="rfc8785-jcs-sha256/v1",
+        source_digest=source_digest,
+        target_digest=target_digest,
+        policy_digest=policy_digest,
+        derivation_digest=canonical_json_digest(
+            {"source": source_digest, "target": target_digest, "decision": policy_digest}
+        ),
+        preconditions=(ArtifactTransformationCheckModel(check_id="selected-facts-admitted", outcome="passed"),),
+        postconditions=(ArtifactTransformationCheckModel(check_id="author-refinement", outcome="passed"),),
+        affected_identities=tuple(sorted(selected_subjects)),
+        preservation=ArtifactTransformationPreservationModel(
+            profile="author-constraint-refinement/v1",
+            outcome="verified",
+            evidence_digests=tuple(sorted({description.authored_ref.ref_digest, target_digest})),
+            limitations=("Only selected scalar facts gain authority; coverage does not close collections.",),
+        ),
+    )
+    return DescriptionPromotion(
+        target,
+        selected_ids,
+        ExperimentReferenceModel(
+            ref_kind="other",
+            ref_id=description.description_id,
+            ref_version=description.description_version,
+            ref_digest=source_digest,
+        ),
+        ExperimentReferenceModel(
+            ref_kind="authoring-input", ref_id=target_id, ref_version=target_version, ref_digest=target_digest
+        ),
+        actor,
+        decision_id,
+        decided_at,
+        transformation,
+    )
+
+
+__all__ = ["DescriptionPromotion", "promote_description"]

--- a/implementations/python/packages/raes_contracts/description_promotion.py
+++ b/implementations/python/packages/raes_contracts/description_promotion.py
@@ -12,7 +12,7 @@ from .contracts.artifact_transformations import (
 )
 from .contracts.base import _parse_rfc3339_datetime
 from .contracts.experiment_references import ExperimentReferenceModel
-from .contracts.realization_descriptions import TypedRealizationDescriptionModel
+from .contracts.realization_descriptions import DescriptionFactModel, TypedRealizationDescriptionModel
 from .description_projection import (
     _bind_author,
     description_conflict,
@@ -32,6 +32,15 @@ from .realization_structure import (
 
 
 @dataclass(frozen=True)
+class DescriptionPromotionDecision:
+    actor: str
+    decision_id: str
+    decided_at: str
+    target_id: str
+    target_version: str
+
+
+@dataclass(frozen=True)
 class DescriptionPromotion:
     constraints: RealizationConstraintDocument
     selected_fact_ids: tuple[str, ...]
@@ -48,77 +57,30 @@ def promote_description(
     authored: RealizationConstraintDocument,
     *,
     fact_ids: tuple[str, ...],
-    actor: str,
-    decision_id: str,
-    decided_at: str,
-    target_id: str,
-    target_version: str,
+    decision: DescriptionPromotionDecision,
 ) -> DescriptionPromotion:
     """Conjoin selected known scalar facts with an isolated original constraint.
 
     This returns a new artifact and decision record. It grants no storage,
     execution, or authoring permission and performs no external operation.
     """
-    decision = {
-        "fact_ids": fact_ids,
-        "actor": actor,
-        "decision_id": decision_id,
-        "decided_at": decided_at,
-        "target_id": target_id,
-        "target_version": target_version,
-    }
-    if not validate_realization_value(decision, python_carriers=True).conformant:
-        raise ValueError("promotion decision exceeds the supported bounds")
-    if any(
-        not isinstance(value, str) or not value.strip() for value in (actor, decision_id, target_id, target_version)
-    ):
-        raise ValueError("promotion requires explicit actor, decision and target identities")
-    _parse_rfc3339_datetime("decided_at", decided_at)
+    _validate_decision(decision, fact_ids)
     description = readmit_description(description)
     if _bind_author(description, authored) is not None:
         raise ValueError("promotion requires the matching original author artifact")
-    if (target_id, target_version) == (description.authored_ref.ref_id, description.authored_ref.ref_version):
-        raise ValueError("promotion must create a new authored artifact identity")
-    if not fact_ids or len(set(fact_ids)) != len(fact_ids):
-        raise ValueError("promotion requires a nonempty unique selection of fact ids")
-    selected = tuple(fact for fact in description.facts if fact.fact_id in fact_ids)
-    if len(selected) != len(fact_ids) or any(
-        fact.state != "known"
-        or not isinstance(fact.value, RealizationLiteral)
-        or fact.profile_bindings
-        or fact.limitations
-        for fact in selected
+    if (decision.target_id, decision.target_version) == (
+        description.authored_ref.ref_id,
+        description.authored_ref.ref_version,
     ):
-        raise ValueError("promotion requires selected known supported scalar facts without limitations")
+        raise ValueError("promotion must create a new authored artifact identity")
+    selected = _promotion_selection(description, fact_ids)
     selected_subjects = {fact.subject for fact in selected}
-    competing = description.model_copy(
-        update={
-            "facts": tuple(
-                fact
-                for fact in description.facts
-                if any(
-                    semantic_address_contains(subject, fact.subject) or semantic_address_contains(fact.subject, subject)
-                    for subject in selected_subjects
-                )
-            )
-        }
-    )
-    if description_conflict(competing) is not None or known_fact_violation(competing, authored) is not None:
-        raise ValueError("promotion cannot resolve conflicting assertions or weaken author constraints")
-    values = description_values(selected)
-    normalized = normalize_realization_literal(values, semantic_profile=authored.semantic_profile)
-    if normalized.document is None:
-        raise ValueError("promotion selection could not be normalized within supported bounds")
-    original = RealizationConstraintDocument.model_validate(authored.model_dump(mode="json"))
-    additional = original.model_copy(update={"root": normalized.document.root})
-    composed = compose_realization_constraints(original, additional)
-    if composed.document is None or not realization_constraint_refines(composed.document, original).conformant:
-        raise ValueError("promotion could not establish a conforming refinement")
-    target = composed.document
+    _validate_competing_facts(description, authored, selected_subjects)
+    target = _compose_promotion(selected, authored)
     source_digest = canonical_json_digest(description.model_dump(mode="json"))
     target_digest = canonical_json_digest(target.model_dump(mode="json"))
     selected_ids = tuple(sorted(fact_ids))
-    policy_digest = canonical_json_digest({**decision, "fact_ids": list(selected_ids)})
+    policy_digest = canonical_json_digest({**_decision_values(decision), "fact_ids": list(selected_ids)})
     transformation = ArtifactTransformationReportModel(
         operation_profile="description-promotion/v1",
         status="success",
@@ -152,13 +114,91 @@ def promote_description(
             ref_digest=source_digest,
         ),
         ExperimentReferenceModel(
-            ref_kind="authoring-input", ref_id=target_id, ref_version=target_version, ref_digest=target_digest
+            ref_kind="authoring-input",
+            ref_id=decision.target_id,
+            ref_version=decision.target_version,
+            ref_digest=target_digest,
         ),
-        actor,
-        decision_id,
-        decided_at,
+        decision.actor,
+        decision.decision_id,
+        decision.decided_at,
         transformation,
     )
 
 
-__all__ = ["DescriptionPromotion", "promote_description"]
+def _decision_values(decision: DescriptionPromotionDecision) -> dict[str, object]:
+    return {
+        "actor": decision.actor,
+        "decision_id": decision.decision_id,
+        "decided_at": decision.decided_at,
+        "target_id": decision.target_id,
+        "target_version": decision.target_version,
+    }
+
+
+def _validate_decision(decision: DescriptionPromotionDecision, fact_ids: tuple[str, ...]) -> None:
+    if not validate_realization_value(
+        {**_decision_values(decision), "fact_ids": fact_ids}, python_carriers=True
+    ).conformant:
+        raise ValueError("promotion decision exceeds the supported bounds")
+    identities = (decision.actor, decision.decision_id, decision.target_id, decision.target_version)
+    if any(not isinstance(value, str) or not value.strip() for value in identities):
+        raise ValueError("promotion requires explicit actor, decision and target identities")
+    _parse_rfc3339_datetime("decided_at", decision.decided_at)
+
+
+def _promotion_selection(
+    description: TypedRealizationDescriptionModel, fact_ids: tuple[str, ...]
+) -> tuple[DescriptionFactModel, ...]:
+    if not fact_ids or len(set(fact_ids)) != len(fact_ids):
+        raise ValueError("promotion requires a nonempty unique selection of fact ids")
+    selected = tuple(fact for fact in description.facts if fact.fact_id in fact_ids)
+    if len(selected) != len(fact_ids) or any(not _promotable_fact(fact) for fact in selected):
+        raise ValueError("promotion requires selected known supported scalar facts without limitations")
+    return selected
+
+
+def _promotable_fact(fact: DescriptionFactModel) -> bool:
+    return (
+        fact.state == "known"
+        and isinstance(fact.value, RealizationLiteral)
+        and not fact.profile_bindings
+        and not fact.limitations
+    )
+
+
+def _validate_competing_facts(
+    description: TypedRealizationDescriptionModel, authored: RealizationConstraintDocument, selected_subjects: set[str]
+) -> None:
+    competing = description.model_copy(
+        update={
+            "facts": tuple(
+                fact
+                for fact in description.facts
+                if any(
+                    semantic_address_contains(subject, fact.subject) or semantic_address_contains(fact.subject, subject)
+                    for subject in selected_subjects
+                )
+            )
+        }
+    )
+    if description_conflict(competing) is not None or known_fact_violation(competing, authored) is not None:
+        raise ValueError("promotion cannot resolve conflicting assertions or weaken author constraints")
+
+
+def _compose_promotion(
+    selected: tuple[DescriptionFactModel, ...], authored: RealizationConstraintDocument
+) -> RealizationConstraintDocument:
+    values = description_values(selected)
+    normalized = normalize_realization_literal(values, semantic_profile=authored.semantic_profile)
+    if normalized.document is None:
+        raise ValueError("promotion selection could not be normalized within supported bounds")
+    original = RealizationConstraintDocument.model_validate(authored.model_dump(mode="json"))
+    additional = original.model_copy(update={"root": normalized.document.root})
+    composed = compose_realization_constraints(original, additional)
+    if composed.document is None or not realization_constraint_refines(composed.document, original).conformant:
+        raise ValueError("promotion could not establish a conforming refinement")
+    return composed.document
+
+
+__all__ = ["DescriptionPromotion", "DescriptionPromotionDecision", "promote_description"]

--- a/implementations/python/packages/raes_contracts/description_reporting.py
+++ b/implementations/python/packages/raes_contracts/description_reporting.py
@@ -1,0 +1,152 @@
+"""Requested-field projection of descriptive facts, using existing demand selectors."""
+
+from __future__ import annotations
+
+from .contracts.experiment_artifacts import _experiment_reference_key
+from .contracts.experiment_manifest_references import ExperimentEvidenceRecordReferenceModel
+from .contracts.realization_descriptions import TypedRealizationDescriptionModel, iter_description_bindings
+from .description_coverage import DescriptionCoverageUnsatisfied, coverage_matches
+from .description_projection import readmit_description
+from .domain_profiles import (
+    admit_domain_profile_bindings,
+)
+from .json_ingress import parse_bounded_json_object
+from .observation_demand import ObservationBasis, ObservationSelector
+from .realization_structure import semantic_address_contains
+from .realization_structure._common import pointer_tokens
+
+
+def project_description(
+    description: TypedRealizationDescriptionModel,
+    selector: ObservationSelector,
+    basis: ObservationBasis,
+    *,
+    exhaustive: bool = False,
+) -> TypedRealizationDescriptionModel:
+    """Protect report depth; producers receive the selector before acquiring facts."""
+    description = readmit_description(description)
+    facts = _selected_facts(description, selector)
+    if selector.max_items is not None and len(facts) > selector.max_items:
+        raise ValueError("description exceeds the requested item bound")
+    if any((fact.provenance or description.provenance).basis is not basis for fact in facts):
+        raise ValueError("description facts must preserve their achieved report basis")
+    coverage = _selected_coverage(description, selector, facts)
+    if any((item.provenance or description.provenance).basis is not basis for item in coverage):
+        raise ValueError("description coverage must preserve its achieved report basis")
+    projected = readmit_description(description.model_copy(update={"facts": facts, "coverage": coverage}))
+    if exhaustive and not _has_exhaustive_coverage(projected, selector):
+        raise DescriptionCoverageUnsatisfied("required description coverage is unsatisfied")
+    return projected
+
+
+def _selected_facts(description, selector):
+    return tuple(
+        fact
+        for fact in description.facts
+        if (
+            selector.data_kind == "field"
+            and semantic_address_contains(selector.semantic_scope, fact.subject)
+            and not any(
+                semantic_address_contains(scope, fact.subject) or semantic_address_contains(fact.subject, scope)
+                for scope in selector.excluded_scopes
+            )
+            and (not selector.component_refs or fact.component_ref in selector.component_refs)
+            and (
+                not selector.window_refs
+                or (fact.provenance or description.provenance).window_ref in selector.window_refs
+            )
+            and (
+                fact.subject in selector.names
+                or (pointer_tokens(fact.subject) and pointer_tokens(fact.subject)[-1] in selector.names)
+            )
+        )
+    )
+
+
+def _selected_coverage(description, selector, facts):
+    selected_ids = {fact.fact_id for fact in facts}
+    return tuple(
+        item.model_copy(
+            update={
+                "fact_ids": tuple(fact_id for fact_id in item.fact_ids if fact_id in selected_ids),
+                "status": item.status if set(item.fact_ids) <= selected_ids else "partial",
+                "recursive": item.recursive and set(item.fact_ids) <= selected_ids,
+            }
+        )
+        for item in description.coverage
+        if selected_ids.intersection(item.fact_ids)
+        and coverage_matches(
+            description,
+            item,
+            scope=selector.semantic_scope,
+            kind=selector.data_kind,
+            profile=selector.coverage_profile,
+            exclusions=selector.excluded_scopes,
+        )
+    )
+
+
+def _has_exhaustive_coverage(projected, selector):
+    return not (
+        not all(
+            any(
+                name == fact.subject or name == pointer_tokens(fact.subject)[-1]
+                for fact in projected.facts
+                if pointer_tokens(fact.subject)
+            )
+            for name in selector.names
+        )
+        or not any(
+            coverage_matches(
+                projected,
+                item,
+                scope=selector.semantic_scope,
+                kind=selector.data_kind,
+                profile=selector.coverage_profile,
+                exclusions=selector.excluded_scopes,
+                complete=True,
+            )
+            for item in projected.coverage
+        )
+    )
+
+
+def admit_description_profiles(description, context, *, policy):
+    """Apply the existing offline profile admission contract to descriptive uses."""
+    description = readmit_description(description)
+    return admit_domain_profile_bindings(
+        tuple(binding for fact in description.facts for binding in fact.profile_bindings),
+        context,
+        policy=policy,
+    )
+
+
+def parse_realization_description(source: str | bytes | bytearray) -> TypedRealizationDescriptionModel:
+    """Use the canonical bounded, duplicate-rejecting JSON ingress."""
+    payload = parse_bounded_json_object(source, max_bytes=1_048_576)
+    return TypedRealizationDescriptionModel.model_validate(payload)
+
+
+def validate_description_evidence(description, basis, evidence_ref) -> None:
+    """Join effective claims to the verifier's unqualified evidence-record identity."""
+    if basis not in {ObservationBasis.OBSERVED, ObservationBasis.INDEPENDENTLY_VERIFIED}:
+        return
+    provenances = (claim.provenance or description.provenance for claim in (*description.facts, *description.coverage))
+    refs = {_experiment_reference_key(ref) for provenance in provenances for ref in provenance.evidence_refs}
+    # Profile provenance uses ID-only strings. Qualifiers on its enclosing fact's
+    # references still have to match in full; resolving to a bare ID loses authority.
+    refs.update(
+        _evidence_record_key(ref)
+        for fact in description.facts
+        for binding in iter_description_bindings(fact.profile_bindings)
+        for ref in binding.provenance.evidence_refs
+    )
+    if refs and refs != {_evidence_record_key(evidence_ref)}:
+        raise ValueError("typed description evidence must join the externally verified reference")
+
+
+def _evidence_record_key(ref_id):
+    return _experiment_reference_key(ExperimentEvidenceRecordReferenceModel(ref_kind="evidence-record", ref_id=ref_id))
+
+
+__all__ = ["admit_description_profiles", "parse_realization_description", "project_description"]

--- a/implementations/python/packages/raes_contracts/description_reporting.py
+++ b/implementations/python/packages/raes_contracts/description_reporting.py
@@ -2,18 +2,35 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any
+
 from .contracts.experiment_artifacts import _experiment_reference_key
 from .contracts.experiment_manifest_references import ExperimentEvidenceRecordReferenceModel
-from .contracts.realization_descriptions import TypedRealizationDescriptionModel, iter_description_bindings
-from .description_coverage import DescriptionCoverageUnsatisfied, coverage_matches
+from .contracts.realization_descriptions import (
+    DescriptionCoverageModel,
+    DescriptionFactModel,
+    TypedRealizationDescriptionModel,
+    iter_description_bindings,
+)
+from .description_coverage import DescriptionCoverageScope, DescriptionCoverageUnsatisfied, coverage_matches
 from .description_projection import readmit_description
 from .domain_profiles import (
+    DomainProfileAdmissionPolicyModel,
+    DomainProfileAdmissionReport,
+    DomainProfileResolutionContextModel,
     admit_domain_profile_bindings,
 )
 from .json_ingress import parse_bounded_json_object
 from .observation_demand import ObservationBasis, ObservationSelector
 from .realization_structure import semantic_address_contains
 from .realization_structure._common import pointer_tokens
+
+
+@dataclass(frozen=True)
+class DescriptionProfileAdmission:
+    context: DomainProfileResolutionContextModel
+    policy: DomainProfileAdmissionPolicyModel
 
 
 def project_description(
@@ -39,31 +56,55 @@ def project_description(
     return projected
 
 
-def _selected_facts(description, selector):
-    return tuple(
-        fact
-        for fact in description.facts
-        if (
-            selector.data_kind == "field"
-            and semantic_address_contains(selector.semantic_scope, fact.subject)
-            and not any(
-                semantic_address_contains(scope, fact.subject) or semantic_address_contains(fact.subject, scope)
-                for scope in selector.excluded_scopes
-            )
-            and (not selector.component_refs or fact.component_ref in selector.component_refs)
-            and (
-                not selector.window_refs
-                or (fact.provenance or description.provenance).window_ref in selector.window_refs
-            )
-            and (
-                fact.subject in selector.names
-                or (pointer_tokens(fact.subject) and pointer_tokens(fact.subject)[-1] in selector.names)
-            )
-        )
+def _fact_scope_selected(fact: DescriptionFactModel, selector: ObservationSelector) -> bool:
+    return semantic_address_contains(selector.semantic_scope, fact.subject) and not any(
+        semantic_address_contains(scope, fact.subject) or semantic_address_contains(fact.subject, scope)
+        for scope in selector.excluded_scopes
     )
 
 
-def _selected_coverage(description, selector, facts):
+def _fact_metadata_selected(
+    fact: DescriptionFactModel, description: TypedRealizationDescriptionModel, selector: ObservationSelector
+) -> bool:
+    source = fact.provenance or description.provenance
+    return (not selector.component_refs or fact.component_ref in selector.component_refs) and (
+        not selector.window_refs or source.window_ref in selector.window_refs
+    )
+
+
+def _fact_name_selected(fact: DescriptionFactModel, selector: ObservationSelector) -> bool:
+    tokens = pointer_tokens(fact.subject)
+    return fact.subject in selector.names or bool(tokens and tokens[-1] in selector.names)
+
+
+def _selected_facts(
+    description: TypedRealizationDescriptionModel, selector: ObservationSelector
+) -> tuple[DescriptionFactModel, ...]:
+    if selector.data_kind != "field":
+        return ()
+    return tuple(
+        fact
+        for fact in description.facts
+        if _fact_scope_selected(fact, selector)
+        and _fact_metadata_selected(fact, description, selector)
+        and _fact_name_selected(fact, selector)
+    )
+
+
+def _coverage_scope(selector: ObservationSelector) -> DescriptionCoverageScope:
+    return DescriptionCoverageScope(
+        scope=selector.semantic_scope,
+        kind=selector.data_kind,
+        profile=selector.coverage_profile,
+        exclusions=selector.excluded_scopes,
+    )
+
+
+def _selected_coverage(
+    description: TypedRealizationDescriptionModel,
+    selector: ObservationSelector,
+    facts: tuple[DescriptionFactModel, ...],
+) -> tuple[DescriptionCoverageModel, ...]:
     selected_ids = {fact.fact_id for fact in facts}
     return tuple(
         item.model_copy(
@@ -78,15 +119,12 @@ def _selected_coverage(description, selector, facts):
         and coverage_matches(
             description,
             item,
-            scope=selector.semantic_scope,
-            kind=selector.data_kind,
-            profile=selector.coverage_profile,
-            exclusions=selector.excluded_scopes,
+            _coverage_scope(selector),
         )
     )
 
 
-def _has_exhaustive_coverage(projected, selector):
+def _has_exhaustive_coverage(projected: TypedRealizationDescriptionModel, selector: ObservationSelector) -> bool:
     return not (
         not all(
             any(
@@ -100,10 +138,7 @@ def _has_exhaustive_coverage(projected, selector):
             coverage_matches(
                 projected,
                 item,
-                scope=selector.semantic_scope,
-                kind=selector.data_kind,
-                profile=selector.coverage_profile,
-                exclusions=selector.excluded_scopes,
+                _coverage_scope(selector),
                 complete=True,
             )
             for item in projected.coverage
@@ -111,7 +146,12 @@ def _has_exhaustive_coverage(projected, selector):
     )
 
 
-def admit_description_profiles(description, context, *, policy):
+def admit_description_profiles(
+    description: TypedRealizationDescriptionModel,
+    context: DomainProfileResolutionContextModel,
+    *,
+    policy: DomainProfileAdmissionPolicyModel,
+) -> DomainProfileAdmissionReport:
     """Apply the existing offline profile admission contract to descriptive uses."""
     description = readmit_description(description)
     return admit_domain_profile_bindings(
@@ -127,7 +167,9 @@ def parse_realization_description(source: str | bytes | bytearray) -> TypedReali
     return TypedRealizationDescriptionModel.model_validate(payload)
 
 
-def validate_description_evidence(description, basis, evidence_ref) -> None:
+def validate_description_evidence(
+    description: TypedRealizationDescriptionModel, basis: ObservationBasis, evidence_ref: str | None
+) -> None:
     """Join effective claims to the verifier's unqualified evidence-record identity."""
     if basis not in {ObservationBasis.OBSERVED, ObservationBasis.INDEPENDENTLY_VERIFIED}:
         return
@@ -145,7 +187,7 @@ def validate_description_evidence(description, basis, evidence_ref) -> None:
         raise ValueError("typed description evidence must join the externally verified reference")
 
 
-def _evidence_record_key(ref_id):
+def _evidence_record_key(ref_id: str | None) -> tuple[Any, ...]:
     return _experiment_reference_key(ExperimentEvidenceRecordReferenceModel(ref_kind="evidence-record", ref_id=ref_id))
 
 

--- a/implementations/python/packages/raes_contracts/observation_reporting.py
+++ b/implementations/python/packages/raes_contracts/observation_reporting.py
@@ -12,7 +12,11 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class AchievedObservationValue:
-    """A value paired with its achieved, rather than requested, basis."""
+    """A value with its achieved basis and optional unqualified evidence-record ID.
+
+    The verifier admits ``evidence_ref`` as a record ID; this API does not admit
+    version, digest, path, or other reference-kind claims.
+    """
 
     value: object
     basis: ObservationBasis
@@ -47,6 +51,8 @@ def realization_description_report(
     *,
     evidence_validator: Callable[[str, AchievedObservationValue], bool] | None = None,
     protector: Callable[[str, AchievedObservationValue, object], AchievedObservationValue] | None = None,
+    profile_context=None,
+    profile_policy=None,
 ) -> tuple[RealizationDescriptionItem, ...]:
     """Project only requested backend-known selections at their truthful basis."""
 
@@ -58,14 +64,50 @@ def realization_description_report(
             if _selector_is_partitioned(resolution, demand, selector):
                 continue
             achieved = selected_values.get(selector.key)
+            achieved = _project_achieved_description(achieved, selector, demand, profile_context, profile_policy)
             if not _achieved_basis_satisfies(selector.key, achieved, demand, evidence_validator):
                 if demand.required:
                     raise ValueError("required-realization-description-basis-unsatisfied")
                 continue
             assert achieved is not None
             protected = _protected_description(selector.key, achieved, demand, protector)
+            protected = _project_achieved_description(protected, selector, demand, profile_context, profile_policy)
+            if not _achieved_basis_satisfies(selector.key, protected, demand, evidence_validator):
+                if demand.required:
+                    raise ValueError("required-realization-description-basis-unsatisfied")
+                continue
             result.append(_description_item(selector.key, protected, demand))
     return tuple(result)
+
+
+def _project_achieved_description(achieved, selector, demand, profile_context, profile_policy):
+    from .contracts.realization_descriptions import TypedRealizationDescriptionModel
+    from .description_coverage import DescriptionCoverageUnsatisfied
+    from .description_reporting import admit_description_profiles, project_description, validate_description_evidence
+    from .domain_profiles import DomainProfileAdmissionPolicyModel, DomainProfileResolutionContextModel
+
+    if achieved is not None and isinstance(achieved.value, TypedRealizationDescriptionModel):
+        try:
+            projected = project_description(
+                achieved.value, selector, achieved.basis, exhaustive=demand.mode.value == "exhaustive"
+            )
+        except DescriptionCoverageUnsatisfied:
+            if demand.required:
+                raise
+            return None
+        validate_description_evidence(projected, achieved.basis, achieved.evidence_ref)
+        if not admit_description_profiles(
+            projected,
+            profile_context or DomainProfileResolutionContextModel(namespace_admissions=(), definitions=()),
+            policy=profile_policy or DomainProfileAdmissionPolicyModel(),
+        ).admitted:
+            raise ValueError("description profile admission refused")
+        return (
+            AchievedObservationValue(projected, achieved.basis, achieved.evidence_ref, achieved.integrity_ref)
+            if projected.facts
+            else None
+        )
+    return achieved
 
 
 def _is_description_selection(demand: EffectiveObservationDemand) -> bool:
@@ -123,6 +165,12 @@ def _protected_description(
     protected = achieved if protector is None else protector(selector_key, achieved, demand)
     if not isinstance(protected, AchievedObservationValue):
         raise ValueError("invalid-observation-report-protection-result")
+    from .contracts.realization_descriptions import TypedRealizationDescriptionModel
+
+    if isinstance(achieved.value, TypedRealizationDescriptionModel) and not isinstance(
+        protected.value, TypedRealizationDescriptionModel
+    ):
+        raise ValueError("protection must preserve the typed description carrier")
     if (protected.basis, protected.evidence_ref) != (achieved.basis, achieved.evidence_ref):
         raise ValueError("observation report protection cannot change evidence claims")
     integrity_missing = protected.integrity_ref is None or not protected.integrity_ref.strip()

--- a/implementations/python/packages/raes_contracts/observation_reporting.py
+++ b/implementations/python/packages/raes_contracts/observation_reporting.py
@@ -7,7 +7,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
-    from .observation_demand import EffectiveObservationDemand, ObservationBasis, ObservationDemandResolution
+    from .description_reporting import DescriptionProfileAdmission
+    from .domain_profiles import DomainProfileAdmissionPolicyModel, DomainProfileResolutionContextModel
+    from .observation_demand import (
+        EffectiveObservationDemand,
+        ObservationBasis,
+        ObservationDemandResolution,
+        ObservationSelector,
+    )
 
 
 @dataclass(frozen=True)
@@ -51,11 +58,18 @@ def realization_description_report(
     *,
     evidence_validator: Callable[[str, AchievedObservationValue], bool] | None = None,
     protector: Callable[[str, AchievedObservationValue, object], AchievedObservationValue] | None = None,
-    profile_context=None,
-    profile_policy=None,
+    profile_context: DomainProfileResolutionContextModel | None = None,
+    profile_policy: DomainProfileAdmissionPolicyModel | None = None,
 ) -> tuple[RealizationDescriptionItem, ...]:
     """Project only requested backend-known selections at their truthful basis."""
 
+    from .description_reporting import DescriptionProfileAdmission
+    from .domain_profiles import DomainProfileAdmissionPolicyModel, DomainProfileResolutionContextModel
+
+    profiles = DescriptionProfileAdmission(
+        profile_context or DomainProfileResolutionContextModel(namespace_admissions=(), definitions=()),
+        profile_policy or DomainProfileAdmissionPolicyModel(),
+    )
     result = []
     for demand in resolution.effective:
         if not _is_description_selection(demand):
@@ -63,28 +77,55 @@ def realization_description_report(
         for selector in demand.selectors:
             if _selector_is_partitioned(resolution, demand, selector):
                 continue
-            achieved = selected_values.get(selector.key)
-            achieved = _project_achieved_description(achieved, selector, demand, profile_context, profile_policy)
-            if not _achieved_basis_satisfies(selector.key, achieved, demand, evidence_validator):
-                if demand.required:
-                    raise ValueError("required-realization-description-basis-unsatisfied")
-                continue
-            assert achieved is not None
-            protected = _protected_description(selector.key, achieved, demand, protector)
-            protected = _project_achieved_description(protected, selector, demand, profile_context, profile_policy)
-            if not _achieved_basis_satisfies(selector.key, protected, demand, evidence_validator):
-                if demand.required:
-                    raise ValueError("required-realization-description-basis-unsatisfied")
-                continue
-            result.append(_description_item(selector.key, protected, demand))
+            item = _report_selected_value(
+                demand, selector, selected_values.get(selector.key), evidence_validator, protector, profiles
+            )
+            if item is not None:
+                result.append(item)
     return tuple(result)
 
 
-def _project_achieved_description(achieved, selector, demand, profile_context, profile_policy):
+def _report_selected_value(
+    demand: EffectiveObservationDemand,
+    selector: ObservationSelector,
+    achieved: AchievedObservationValue | None,
+    evidence_validator: Callable[[str, AchievedObservationValue], bool] | None,
+    protector: Callable[[str, AchievedObservationValue, object], AchievedObservationValue] | None,
+    profiles: DescriptionProfileAdmission,
+) -> RealizationDescriptionItem | None:
+    achieved = _project_achieved_description(achieved, selector, demand, profiles)
+    if not _require_achieved_basis(selector.key, achieved, demand, evidence_validator):
+        return None
+    assert achieved is not None
+    protected = _protected_description(selector.key, achieved, demand, protector)
+    projected = _project_achieved_description(protected, selector, demand, profiles)
+    if not _require_achieved_basis(selector.key, projected, demand, evidence_validator):
+        return None
+    assert projected is not None
+    return _description_item(selector.key, projected, demand)
+
+
+def _require_achieved_basis(
+    selector_key: str,
+    achieved: AchievedObservationValue | None,
+    demand: EffectiveObservationDemand,
+    evidence_validator: Callable[[str, AchievedObservationValue], bool] | None,
+) -> bool:
+    satisfies = _achieved_basis_satisfies(selector_key, achieved, demand, evidence_validator)
+    if demand.required and not satisfies:
+        raise ValueError("required-realization-description-basis-unsatisfied")
+    return satisfies
+
+
+def _project_achieved_description(
+    achieved: AchievedObservationValue | None,
+    selector: ObservationSelector,
+    demand: EffectiveObservationDemand,
+    profiles: DescriptionProfileAdmission,
+) -> AchievedObservationValue | None:
     from .contracts.realization_descriptions import TypedRealizationDescriptionModel
     from .description_coverage import DescriptionCoverageUnsatisfied
     from .description_reporting import admit_description_profiles, project_description, validate_description_evidence
-    from .domain_profiles import DomainProfileAdmissionPolicyModel, DomainProfileResolutionContextModel
 
     if achieved is not None and isinstance(achieved.value, TypedRealizationDescriptionModel):
         try:
@@ -98,8 +139,8 @@ def _project_achieved_description(achieved, selector, demand, profile_context, p
         validate_description_evidence(projected, achieved.basis, achieved.evidence_ref)
         if not admit_description_profiles(
             projected,
-            profile_context or DomainProfileResolutionContextModel(namespace_admissions=(), definitions=()),
-            policy=profile_policy or DomainProfileAdmissionPolicyModel(),
+            profiles.context,
+            policy=profiles.policy,
         ).admitted:
             raise ValueError("description profile admission refused")
         return (
@@ -163,6 +204,14 @@ def _protected_description(
     if protector is None and protection_required:
         raise ValueError("observation-report-protection-runtime-unavailable")
     protected = achieved if protector is None else protector(selector_key, achieved, demand)
+    _validate_protected_carrier(achieved, protected)
+    integrity_missing = protected.integrity_ref is None or not protected.integrity_ref.strip()
+    if demand.integrity not in {None, "none"} and integrity_missing:
+        raise ValueError("observation report integrity policy must produce an integrity reference")
+    return protected
+
+
+def _validate_protected_carrier(achieved: AchievedObservationValue, protected: AchievedObservationValue) -> None:
     if not isinstance(protected, AchievedObservationValue):
         raise ValueError("invalid-observation-report-protection-result")
     from .contracts.realization_descriptions import TypedRealizationDescriptionModel
@@ -173,10 +222,6 @@ def _protected_description(
         raise ValueError("protection must preserve the typed description carrier")
     if (protected.basis, protected.evidence_ref) != (achieved.basis, achieved.evidence_ref):
         raise ValueError("observation report protection cannot change evidence claims")
-    integrity_missing = protected.integrity_ref is None or not protected.integrity_ref.strip()
-    if demand.integrity not in {None, "none"} and integrity_missing:
-        raise ValueError("observation report integrity policy must produce an integrity reference")
-    return protected
 
 
 def _description_item(

--- a/implementations/python/packages/raes_runtime/observation_execution.py
+++ b/implementations/python/packages/raes_runtime/observation_execution.py
@@ -6,11 +6,13 @@ from collections.abc import Callable, Mapping
 from typing import Protocol
 
 from raes_backend_protocols.capabilities import BackendManifest
+from raes_contracts.description_reporting import DescriptionProfileAdmission
 from raes_contracts.diagnostics import Diagnostic
 from raes_contracts.observation_demand import (
     AchievedObservationValue,
     EffectiveObservationDemand,
     ObservationBasis,
+    ObservationDemandResolution,
     ObservationLifecycleItem,
     ObservationLifecycleStage,
     ObservationPurpose,
@@ -19,6 +21,7 @@ from raes_contracts.observation_demand import (
     observation_selector_has_more_specific_policy,
     realization_description_report,
 )
+from raes_contracts.observation_reporting import RealizationDescriptionItem
 from raes_contracts.runtime_state import RuntimeSnapshot
 
 from .observation_admission import (
@@ -92,8 +95,7 @@ class ConfiguredObservationRuntime:
         redactors: Mapping[str, Redactor] | None = None,
         integrity_providers: Mapping[str, IntegrityProvider] | None = None,
         evidence_verifier: EvidenceVerifier | None = None,
-        description_profile_context=None,
-        description_profile_policy=None,
+        description_profiles: DescriptionProfileAdmission | None = None,
     ) -> None:
         _require_unique_capability_ids(capabilities)
         self._capabilities = capabilities
@@ -102,8 +104,7 @@ class ConfiguredObservationRuntime:
         self._redactors = dict(redactors or {})
         self._integrity_providers = dict(integrity_providers or {})
         self._evidence_verifier = evidence_verifier
-        self.description_profile_context = description_profile_context
-        self.description_profile_policy = description_profile_policy
+        self.description_profiles = description_profiles
         for capability in capabilities:
             _validate_capability_callbacks(
                 capability,
@@ -241,28 +242,7 @@ def _execute_admitted_plan_observation(
             supported=supported,
             protector=runtime.protect,
         )
-        description_selectors = {
-            selector.key: selector
-            for demand in resolution.effective
-            if demand.purpose is ObservationPurpose.REALIZATION_DESCRIPTION
-            for selector in demand.selectors
-            if not observation_selector_has_more_specific_policy(resolution.effective, demand, selector)
-        }
-        achieved = {
-            key: value
-            for key, selector in description_selectors.items()
-            if (value := runtime.describe(selector, plan, snapshot)) is not None
-        }
-        description = realization_description_report(
-            resolution,
-            achieved,
-            profile_context=getattr(runtime, "description_profile_context", None),
-            profile_policy=getattr(runtime, "description_profile_policy", None),
-            evidence_validator=lambda key, value: runtime.verify_evidence(
-                description_selectors[key], value, plan, snapshot
-            ),
-            protector=lambda key, value, demand: _protect_description(runtime, key, value, demand),
-        )
+        description = _describe_admitted_plan(resolution, runtime, plan, snapshot)
         if manifest is None:
             raise ValueError("observation execution requires a backend manifest")
         execution = prepare_observation_execution(
@@ -314,3 +294,34 @@ __all__ = [
     "execute_plan_observation_demand",
     "observation_submission_diagnostic",
 ]
+
+
+def _describe_admitted_plan(
+    resolution: ObservationDemandResolution,
+    runtime: ObservationRuntime,
+    plan: Plan,
+    snapshot: RuntimeSnapshot,
+) -> tuple[RealizationDescriptionItem, ...]:
+    description_selectors = {
+        selector.key: selector
+        for demand in resolution.effective
+        if demand.purpose is ObservationPurpose.REALIZATION_DESCRIPTION
+        for selector in demand.selectors
+        if not observation_selector_has_more_specific_policy(resolution.effective, demand, selector)
+    }
+    achieved = {
+        key: value
+        for key, selector in description_selectors.items()
+        if (value := runtime.describe(selector, plan, snapshot)) is not None
+    }
+    profiles = getattr(runtime, "description_profiles", None)
+    return realization_description_report(
+        resolution,
+        achieved,
+        profile_context=profiles.context if profiles else None,
+        profile_policy=profiles.policy if profiles else None,
+        evidence_validator=lambda key, value: runtime.verify_evidence(
+            description_selectors[key], value, plan, snapshot
+        ),
+        protector=lambda key, value, demand: _protect_description(runtime, key, value, demand),
+    )

--- a/implementations/python/packages/raes_runtime/observation_execution.py
+++ b/implementations/python/packages/raes_runtime/observation_execution.py
@@ -92,6 +92,8 @@ class ConfiguredObservationRuntime:
         redactors: Mapping[str, Redactor] | None = None,
         integrity_providers: Mapping[str, IntegrityProvider] | None = None,
         evidence_verifier: EvidenceVerifier | None = None,
+        description_profile_context=None,
+        description_profile_policy=None,
     ) -> None:
         _require_unique_capability_ids(capabilities)
         self._capabilities = capabilities
@@ -100,6 +102,8 @@ class ConfiguredObservationRuntime:
         self._redactors = dict(redactors or {})
         self._integrity_providers = dict(integrity_providers or {})
         self._evidence_verifier = evidence_verifier
+        self.description_profile_context = description_profile_context
+        self.description_profile_policy = description_profile_policy
         for capability in capabilities:
             _validate_capability_callbacks(
                 capability,
@@ -252,6 +256,8 @@ def _execute_admitted_plan_observation(
         description = realization_description_report(
             resolution,
             achieved,
+            profile_context=getattr(runtime, "description_profile_context", None),
+            profile_policy=getattr(runtime, "description_profile_policy", None),
             evidence_validator=lambda key, value: runtime.verify_evidence(
                 description_selectors[key], value, plan, snapshot
             ),

--- a/implementations/python/packages/raes_runtime/observation_results.py
+++ b/implementations/python/packages/raes_runtime/observation_results.py
@@ -11,6 +11,8 @@ from raes_contracts.contracts import (
     ExperimentRealizedFormDisclosureModel,
     ExperimentReferenceModel,
 )
+from raes_contracts.contracts.realization_descriptions import TypedRealizationDescriptionModel
+from raes_contracts.description_projection import readmit_description
 from raes_contracts.observation_demand import (
     ObservationBasis,
     ObservationLifecycleItem,
@@ -138,6 +140,7 @@ def _realized_form_disclosure(
         else [ExperimentEvidenceRecordReferenceModel(ref_kind="evidence-record", ref_id=evidence_ref)]
     )
     integrity = "" if integrity_ref is None else f" Integrity reference: {integrity_ref}."
+    description = readmit_description(value) if isinstance(value, TypedRealizationDescriptionModel) else None
     return ExperimentRealizedFormDisclosureModel(
         concern_id=selector_key,
         concern_kind="other",
@@ -147,7 +150,12 @@ def _realized_form_disclosure(
             ref_id=manifest.identity.name,
             ref_version=manifest.identity.version,
         ),
-        realized_value_summary=_json_text(value),
+        realized_value_summary=(
+            f"Requested typed description with {len(description.facts)} facts."
+            if description is not None
+            else _json_text(value)
+        ),
+        typed_description=description,
         disclosure=f"Requested realization description achieved with basis '{basis.value}'.{integrity}",
         evidence_refs=evidence_refs,
     )
@@ -155,10 +163,18 @@ def _realized_form_disclosure(
 
 def _json_value(value: object) -> object:
     try:
-        encoded = json.dumps(value, ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(",", ":"))
+        encoded = json.dumps(
+            value, default=_description_json, ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(",", ":")
+        )
         return json.loads(encoded)
     except (TypeError, ValueError) as exc:
         raise ValueError("observation result must be JSON-compatible") from exc
+
+
+def _description_json(value: object) -> object:
+    if isinstance(value, TypedRealizationDescriptionModel):
+        return readmit_description(value).model_dump(mode="json", exclude_none=True)
+    raise TypeError("unsupported observation result value")
 
 
 def _json_text(value: object) -> str:

--- a/implementations/python/tests/evidence_test_fixtures.py
+++ b/implementations/python/tests/evidence_test_fixtures.py
@@ -1,0 +1,13 @@
+"""Cache committed evidence reads while giving each test an isolated copy."""
+
+from copy import deepcopy
+from functools import cache
+
+
+@cache
+def _committed_bundle(loader, root):
+    return loader(root)
+
+
+def copy_bundle(loader, root):
+    return deepcopy(_committed_bundle(loader, root))

--- a/implementations/python/tests/test_formal_semantic_validation.py
+++ b/implementations/python/tests/test_formal_semantic_validation.py
@@ -9,11 +9,11 @@ from types import SimpleNamespace
 
 import pytest
 import tools.check_formal_semantic_validation as formal_validation
+from evidence_test_fixtures import copy_bundle
 from tools.check_formal_semantic_validation import (
     REQUIRED_CLAIM_CLASS_IDS,
     REQUIRED_PARTICIPANT_OBLIGATION_IDS,
     _replay_participant_tests,
-    evaluate,
     load_bundle,
     load_release_bundles,
     load_retest_bundle,
@@ -32,7 +32,7 @@ def _rule_ids(failures: list[object]) -> set[str]:
 
 
 def _bundle() -> tuple[dict, dict, dict, dict, dict]:
-    return tuple(deepcopy(item) for item in load_bundle(REPO_ROOT))  # type: ignore[return-value]
+    return tuple(deepcopy(item) for item in copy_bundle(load_bundle, REPO_ROOT))  # type: ignore[return-value]
 
 
 def test_historical_bundle_integrity_is_clean() -> None:
@@ -40,7 +40,7 @@ def test_historical_bundle_integrity_is_clean() -> None:
 
 
 def test_atomic_release_index_validates_every_historical_bundle() -> None:
-    releases = load_release_bundles(REPO_ROOT)
+    releases = copy_bundle(load_release_bundles, REPO_ROOT)
 
     assert [release.manifest["revision"] for release in releases] == [
         "1.0.0",
@@ -54,22 +54,25 @@ def test_atomic_release_index_validates_every_historical_bundle() -> None:
         "7.0.0",
         "8.0.0",
         "9.0.0",
+        "10.0.0",
     ]
     assert all(validate_release_bundle(REPO_ROOT, release) == [] for release in releases)
 
 
 def test_current_retest_bundle_is_coherent_and_clean() -> None:
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(REPO_ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
 
-    assert release.manifest["revision"] == "9.0.0"
+    assert release.manifest["revision"] == "10.0.0"
     assert protocol["revision"] == corpus["revision"] == "2.0.0"
-    assert snapshot["baseline"]["release_revision"] == "8.0.0"
+    assert snapshot["baseline"]["release_revision"] == "9.0.0"
     assert snapshot["deviations"] == []
     assert validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis) == []
 
 
 def test_recursive_realization_capture_retains_exact_compiler_deviations() -> None:
-    release = next(item for item in load_release_bundles(REPO_ROOT) if item.manifest["revision"] == "8.0.0")
+    release = next(
+        item for item in copy_bundle(load_release_bundles, REPO_ROOT) if item.manifest["revision"] == "8.0.0"
+    )
     snapshot = release.snapshot
     assert snapshot["baseline"]["release_revision"] == "7.0.0"
     assert len(snapshot["deviations"]) == 2
@@ -82,7 +85,7 @@ def test_recursive_realization_capture_retains_exact_compiler_deviations() -> No
 def test_historical_release_validation_does_not_replay_current_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    release = deepcopy(load_release_bundles(REPO_ROOT)[2])
+    release = deepcopy(copy_bundle(load_release_bundles, REPO_ROOT)[2])
 
     def fail_if_replayed(*_args: object, **_kwargs: object) -> dict[str, object]:
         raise AssertionError("historical evidence must not replay current code")
@@ -148,7 +151,9 @@ def test_classification_replay_drift_is_not_accepted_by_a_digest_pair(case_id, r
 
 
 def test_retest_gate_requires_explicit_baseline_drift_disposition() -> None:
-    release = next(item for item in load_release_bundles(REPO_ROOT) if item.manifest["revision"] == "5.0.0")
+    release = next(
+        item for item in copy_bundle(load_release_bundles, REPO_ROOT) if item.manifest["revision"] == "5.0.0"
+    )
     protocol, corpus, snapshot, analysis = (
         deepcopy(release.protocol),
         deepcopy(release.corpus),
@@ -163,7 +168,9 @@ def test_retest_gate_requires_explicit_baseline_drift_disposition() -> None:
 
 
 def test_retest_gate_rejects_stale_baseline_observation_value() -> None:
-    release = next(item for item in load_release_bundles(REPO_ROOT) if item.manifest["revision"] == "5.0.0")
+    release = next(
+        item for item in copy_bundle(load_release_bundles, REPO_ROOT) if item.manifest["revision"] == "5.0.0"
+    )
     protocol, corpus, snapshot, analysis = (
         deepcopy(release.protocol),
         deepcopy(release.corpus),
@@ -178,7 +185,7 @@ def test_retest_gate_rejects_stale_baseline_observation_value() -> None:
 
 
 def test_retest_gate_rejects_changed_baseline_release_digest() -> None:
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(REPO_ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
     snapshot = deepcopy(snapshot)
     snapshot["baseline"]["release_sha256"] = "0" * 64
 
@@ -188,7 +195,7 @@ def test_retest_gate_rejects_changed_baseline_release_digest() -> None:
 
 
 def test_current_retest_requires_drift_disposition_for_production_evidence_cases() -> None:
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(REPO_ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
     snapshot = deepcopy(snapshot)
     observation = next(item for item in snapshot["observations"] if item["case_id"] == "finite-domain-satisfiable-v2")
     observation["result_digest"] = "0" * 64
@@ -225,7 +232,7 @@ def test_retest_production_evidence_contains_governed_payloads() -> None:
 
 
 def test_atomic_release_rejects_changed_snapshot_digest() -> None:
-    release = deepcopy(load_release_bundles(REPO_ROOT)[0])
+    release = deepcopy(copy_bundle(load_release_bundles, REPO_ROOT)[0])
     release.manifest["snapshot_sha256"] = "0" * 64
 
     failures = validate_release_bundle(REPO_ROOT, release)
@@ -233,41 +240,60 @@ def test_atomic_release_rejects_changed_snapshot_digest() -> None:
     assert "formal-validation-release-digest" in _rule_ids(failures)
 
 
-def test_retest_gate_rejects_missing_production_evidence_join() -> None:
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(REPO_ROOT)
+@pytest.mark.parametrize("case_id", ["finite-domain-satisfiable-v2", "typed-exploit-path-valid-v2"])
+def test_retest_gate_rejects_missing_production_evidence_join(case_id) -> None:
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
     snapshot = deepcopy(snapshot)
-    observation = next(item for item in snapshot["observations"] if item["case_id"] == "finite-domain-satisfiable-v2")
+    observation = next(item for item in snapshot["observations"] if item["case_id"] == case_id)
     observation["evidence_artifact_path"] = None
 
     failures = validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis)
 
-    assert "formal-validation-production-evidence-join" in _rule_ids(failures)
+    assert (
+        "formal-validation-production-evidence-join",
+        f"case {case_id!r} lacks an atomically selected input or evidence artifact",
+        release.manifest["snapshot_path"],
+    ) in {(f.rule_id, f.message, f.path) for f in failures}
 
 
-def test_retest_gate_rejects_forged_production_configuration_digest() -> None:
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(REPO_ROOT)
+@pytest.mark.parametrize("case_id", ["finite-domain-satisfiable-v2", "typed-exploit-path-valid-v2"])
+def test_retest_gate_rejects_forged_production_configuration_digest(case_id) -> None:
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
     snapshot = deepcopy(snapshot)
-    observation = next(item for item in snapshot["observations"] if item["case_id"] == "finite-domain-satisfiable-v2")
+    observation = next(item for item in snapshot["observations"] if item["case_id"] == case_id)
     observation["configuration_digest"] = f"sha256:{'0' * 64}"
 
     failures = validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis)
 
-    assert "formal-validation-production-evidence-join" in _rule_ids(failures)
+    assert (
+        "formal-validation-production-evidence-join",
+        f"case {case_id!r} source, configuration, outcome, CLI, replay, or evidence joins drifted",
+        release.manifest["snapshot_path"],
+    ) in {(f.rule_id, f.message, f.path) for f in failures}
 
 
+@pytest.mark.parametrize("case_id", ["finite-domain-satisfiable-v2", "typed-exploit-path-valid-v2"])
 def test_retest_gate_authenticates_immutable_evidence_payload_before_migration(
     monkeypatch: pytest.MonkeyPatch,
+    case_id,
 ) -> None:
+    from raes_processor.exploit_path import analyze_exploit_path_file
     from raes_processor.satisfiability import analyze_scenario_file
 
-    release = next(item for item in load_release_bundles(REPO_ROOT) if item.manifest["revision"] == "3.0.0")
+    release = next(
+        item for item in copy_bundle(load_release_bundles, REPO_ROOT) if item.manifest["revision"] == "3.0.0"
+    )
     protocol, corpus, snapshot, analysis = release.protocol, release.corpus, release.snapshot, release.analysis
-    evidence_path = "docs/research/formal-semantic-validation/evidence/finite-domain-satisfiable-v2.json"
-    fixture_path = REPO_ROOT / "docs/research/formal-semantic-validation/corpus/satisfiable-control.sdl.yaml"
-    replacement = analyze_scenario_file(
-        fixture_path,
-        profile="raes-finite-domain-satisfiability-v1",
-    ).model_dump(mode="json")
+    case = next(item for item in corpus["cases"] if item["case_id"] == case_id)
+    observation = next(item for item in snapshot["observations"] if item["case_id"] == case_id)
+    evidence_path = observation["evidence_artifact_path"]
+    fixture_path = REPO_ROOT / case["fixture_path"]
+    analyzer, profile = (
+        (analyze_scenario_file, "raes-finite-domain-satisfiability-v1")
+        if case["replay_mode"] == "satisfiability"
+        else (analyze_exploit_path_file, "raes-exploit-path-analysis-v1")
+    )
+    replacement = analyzer(fixture_path, profile=profile).model_dump(mode="json")
     original_loader = formal_validation.load_bounded_json_object
 
     def replace_stored_evidence(repo_root: Path, relative_path: str, *, max_bytes: int):
@@ -281,22 +307,31 @@ def test_retest_gate_authenticates_immutable_evidence_payload_before_migration(
 
     failures = validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis, replay_current=False)
 
-    assert "formal-validation-production-evidence-join" in _rule_ids(failures)
+    assert (
+        "formal-validation-production-evidence-join",
+        f"case {case_id!r} source, configuration, outcome, CLI, replay, or evidence joins drifted",
+        release.manifest["snapshot_path"],
+    ) in {(f.rule_id, f.message, f.path) for f in failures}
 
 
-def test_retest_gate_rejects_test_local_substitute_command() -> None:
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(REPO_ROOT)
+@pytest.mark.parametrize("case_id", ["finite-domain-satisfiable-v2", "typed-exploit-path-valid-v2"])
+def test_retest_gate_rejects_test_local_substitute_command(case_id) -> None:
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
     snapshot = deepcopy(snapshot)
-    command = next(item for item in snapshot["commands"] if item["command_id"] == "finite-domain-satisfiable-v2")
+    command = next(item for item in snapshot["commands"] if item["command_id"] == case_id)
     command["argv"][0] = "implementations/python/tests/fake-analyzer.py"
 
     failures = validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis)
 
-    assert "formal-validation-production-command" in _rule_ids(failures)
+    assert (
+        "formal-validation-production-command",
+        f"case {case_id!r} must use its production CLI with fixed offline argv",
+        release.manifest["snapshot_path"],
+    ) in {(f.rule_id, f.message, f.path) for f in failures}
 
 
 def test_retest_analysis_status_is_derived_not_copied_from_ceiling() -> None:
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(REPO_ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
     snapshot = deepcopy(snapshot)
     analysis = deepcopy(analysis)
     observation = next(item for item in snapshot["observations"] if item["case_id"] == "finite-domain-unsatisfiable-v2")
@@ -311,7 +346,7 @@ def test_retest_analysis_status_is_derived_not_copied_from_ceiling() -> None:
 
 
 def test_retest_gate_rejects_promotion_from_historical_unsupported_cases() -> None:
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(REPO_ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
     corpus = deepcopy(corpus)
     snapshot = deepcopy(snapshot)
     removed_ids = {"typed-exploit-path-valid-v2", "typed-exploit-path-invalid-v2"}
@@ -425,9 +460,16 @@ def test_gate_replays_participant_tests_instead_of_trusting_pass_labels() -> Non
     def failed_replay(_repo_root: Path, _test_refs: list[str]) -> tuple[bool, str]:
         return False, "seeded participant fixture failure"
 
-    failures = evaluate(REPO_ROOT, participant_test_runner=failed_replay)
-
-    assert "formal-validation-participant-replay" in _rule_ids(failures)
+    releases = [
+        SimpleNamespace(
+            manifest={"revision": "1.0.0", "snapshot_path": "snapshot.json"},
+            protocol={"participant_obligations": [{"positive_test_ref": "positive", "negative_test_ref": "negative"}]},
+        )
+    ]
+    failures = formal_validation._participant_replay_failures(REPO_ROOT, releases, failed_replay)
+    assert [(failure.rule_id, failure.message, failure.path) for failure in failures] == [
+        ("formal-validation-participant-replay", "seeded participant fixture failure", "snapshot.json")
+    ]
 
 
 @pytest.mark.parametrize(
@@ -606,7 +648,7 @@ def test_gate_rejects_mutations_of_every_semantic_integrity_rule_family(
 
 
 def test_satisfiability_supplement_has_complete_replayable_control_matrix() -> None:
-    manifest, snapshot, analysis = load_satisfiability_analysis(REPO_ROOT)
+    manifest, snapshot, analysis = copy_bundle(load_satisfiability_analysis, REPO_ROOT)
 
     assert manifest["revision"] == "2.0.0"
     assert analysis["evidence_status"] == "demonstrated"
@@ -620,7 +662,7 @@ def test_satisfiability_supplement_has_complete_replayable_control_matrix() -> N
 
 
 def test_satisfiability_gate_rejects_missing_unsupported_control() -> None:
-    manifest, snapshot, analysis = load_satisfiability_analysis(REPO_ROOT)
+    manifest, snapshot, analysis = copy_bundle(load_satisfiability_analysis, REPO_ROOT)
     analysis = deepcopy(analysis)
     analysis["cases"] = [item for item in analysis["cases"] if item["control"] != "unsupported"]
 
@@ -643,7 +685,7 @@ def test_satisfiability_gate_rejects_mutated_frozen_observations(
     field: str,
     replacement: str,
 ) -> None:
-    manifest, snapshot, analysis = load_satisfiability_analysis(REPO_ROOT)
+    manifest, snapshot, analysis = copy_bundle(load_satisfiability_analysis, REPO_ROOT)
     analysis = deepcopy(analysis)
     unsupported = next(item for item in analysis["cases"] if item["control"] == "unsupported")
     unsupported[field] = replacement
@@ -654,7 +696,7 @@ def test_satisfiability_gate_rejects_mutated_frozen_observations(
 
 
 def test_satisfiability_gate_rejects_unsafe_fixture_and_unknown_fields() -> None:
-    manifest, snapshot, analysis = load_satisfiability_analysis(REPO_ROOT)
+    manifest, snapshot, analysis = copy_bundle(load_satisfiability_analysis, REPO_ROOT)
     unsafe = deepcopy(analysis)
     unsafe["cases"][0]["fixture_path"] = "../outside.sdl.yaml"
     unknown = deepcopy(analysis)
@@ -669,7 +711,7 @@ def test_satisfiability_gate_rejects_unsafe_fixture_and_unknown_fields() -> None
 
 
 def test_satisfiability_gate_rejects_mutated_execution_snapshot() -> None:
-    manifest, snapshot, analysis = load_satisfiability_analysis(REPO_ROOT)
+    manifest, snapshot, analysis = copy_bundle(load_satisfiability_analysis, REPO_ROOT)
     snapshot = deepcopy(snapshot)
     snapshot["observations"][0]["actual_outcome"] = "unsatisfiable"
 

--- a/implementations/python/tests/test_formal_semantic_validation_review.py
+++ b/implementations/python/tests/test_formal_semantic_validation_review.py
@@ -1,0 +1,217 @@
+"""Evidence failures identify the exact integrity boundary that rejected them."""
+
+import subprocess
+
+import pytest
+from evidence_test_fixtures import copy_bundle
+from test_formal_semantic_validation import REPO_ROOT, _bundle
+from tools.check_formal_semantic_validation import (
+    load_release_bundles,
+    load_retest_bundle,
+    validate_bundle,
+    validate_release_bundle,
+    validate_retest_bundle,
+)
+from tools.formal_semantic_validation import _production, _retest, _snapshot
+
+
+def identities(failures):
+    return {(f.rule_id, f.message, f.path) for f in failures}
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "rule", "message"),
+    [
+        ("raes_revision", "dev", "formal-validation-revision-pin", "retest snapshot must pin a full RAES commit"),
+        (
+            "versions",
+            {},
+            "formal-validation-version-disclosure",
+            "retest snapshot must record the bounded output-affecting versions",
+        ),
+    ],
+)
+def test_retest_requires_immutable_revision_and_version_disclosure(field, value, rule, message):
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
+    snapshot[field] = value
+    failures = validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis)
+    assert (rule, message, release.manifest["snapshot_path"]) in identities(failures)
+
+
+@pytest.mark.parametrize("version", [1, 2])
+@pytest.mark.parametrize(
+    ("field", "value"), [("actual_outcome", "accepted"), ("diagnostic_kind", "invented"), ("result_digest", "0" * 64)]
+)
+def test_unsupported_observations_cannot_fabricate_results(version, field, value):
+    observation = {
+        "case_id": "unsupported",
+        "actual_outcome": "unsupported",
+        "diagnostic_kind": None,
+        "result_digest": None,
+    }
+    failures = []
+
+    def validate():
+        if version == 1:
+            _snapshot._validate_snapshot_replay(
+                REPO_ROOT, {"replay_mode": "unsupported"}, observation, failures, "snapshot.json", replay_cases=True
+            )
+        else:
+            _retest._validate_retained_retest_observation(
+                REPO_ROOT, {"replay_mode": "unsupported"}, observation, failures, "snapshot.json"
+            )
+
+    validate()
+    assert failures == []
+    observation[field] = value
+    validate()
+    message = (
+        "unsupported observation 'unsupported' must not synthesize diagnostics or results"
+        if version == 1
+        else "historical unsupported case 'unsupported' must remain unsupported"
+    )
+    assert identities(failures) == {("formal-validation-unsupported-observation", message, "snapshot.json")}
+
+
+@pytest.mark.parametrize("version", [1, 2])
+@pytest.mark.parametrize("error", [OSError, ValueError])
+def test_retained_replay_exceptions_are_failures(monkeypatch, version, error):
+    module = _snapshot if version == 1 else _retest
+
+    def fail(*_args):
+        raise error("seeded failure")
+
+    monkeypatch.setattr(module, "replay_case", fail)
+    case, observation = {"case_id": "control", "replay_mode": "parse"}, {"case_id": "control"}
+    failures = []
+    if version == 1:
+        _snapshot._validate_snapshot_replay(REPO_ROOT, case, observation, failures, "snapshot.json", replay_cases=True)
+        message = "could not replay 'control': seeded failure"
+    else:
+        _retest._validate_retained_retest_observation(REPO_ROOT, case, observation, failures, "snapshot.json")
+        message = f"retained case 'control' could not replay ({error.__name__})"
+    assert identities(failures) == {("formal-validation-replay-error", message, "snapshot.json")}
+
+
+@pytest.mark.parametrize("case_id", ["finite-domain-satisfiable-v2", "typed-exploit-path-valid-v2"])
+@pytest.mark.parametrize("error", [OSError, ValueError, RuntimeError, subprocess.SubprocessError])
+def test_production_replay_exceptions_are_failures(monkeypatch, case_id, error):
+    release, _protocol, corpus, snapshot, _analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
+    case = next(item for item in corpus["cases"] if item["case_id"] == case_id)
+    observation = next(item for item in snapshot["observations"] if item["case_id"] == case_id)
+    command = next(item for item in snapshot["commands"] if item["command_id"] == case_id)
+    context = _production._ProductionObservationContext(
+        REPO_ROOT, {item["path"]: item for item in release.manifest["artifacts"]}
+    )
+
+    def fail(*_args, **_kwargs):
+        raise error("seeded failure")
+
+    monkeypatch.setattr(_production, "_replay_production_evidence", fail)
+    failures = []
+    _production._validate_production_evidence_observation(
+        context, case, observation, command, failures, "snapshot.json"
+    )
+    assert identities(failures) == {
+        (
+            "formal-validation-production-replay",
+            f"case {case_id!r} production replay failed ({error.__name__})",
+            "snapshot.json",
+        )
+    }
+
+
+def test_retest_rejects_an_extra_atomically_selected_artifact():
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
+    release.manifest["artifacts"].append(
+        {"artifact_id": "extra", "kind": "production-evidence", "path": "extra.json", "sha256": "0" * 64}
+    )
+    failures = validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis)
+    assert (
+        "formal-validation-production-evidence-join",
+        "the atomic release must select exactly every production input and evidence artifact",
+        release.manifest_path,
+    ) in identities(failures)
+
+
+def test_retest_rejects_missing_production_command_selection():
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
+    snapshot["commands"] = [
+        item for item in snapshot["commands"] if item["command_id"] != "typed-exploit-path-valid-v2"
+    ]
+    failures = validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis)
+    assert (
+        "formal-validation-production-command",
+        "every production evidence case needs one fixed command",
+        release.manifest["snapshot_path"],
+    ) in identities(failures)
+
+
+@pytest.mark.parametrize(
+    ("artifact", "keys", "value", "rule"),
+    [
+        ("corpus", ("cases", 0, "case_id"), "", "formal-validation-case-ids"),
+        ("snapshot", ("observations",), {}, "formal-validation-observations"),
+        ("snapshot", ("participant_observations",), {}, "formal-validation-participant-observations"),
+        ("analysis", ("claim_results",), {}, "formal-validation-analysis-results"),
+        ("analysis", ("claim_results", 0, "claim_class_id"), "unknown", "formal-validation-analysis-result-join"),
+    ],
+)
+def test_historical_gate_rejects_remaining_integrity_mutations(artifact, keys, value, rule):
+    manifest, protocol, corpus, snapshot, analysis = _bundle()
+    target = {"corpus": corpus, "snapshot": snapshot, "analysis": analysis}[artifact]
+    for key in keys[:-1]:
+        target = target[key]
+    target[keys[-1]] = value
+    failures = validate_bundle(REPO_ROOT, manifest, protocol, corpus, snapshot, analysis, replay_cases=False)
+    assert rule in {f.rule_id for f in failures}
+
+
+@pytest.mark.parametrize(
+    ("keys", "value", "rule"),
+    [
+        (("unexpected",), True, "formal-validation-release-shape"),
+        (("revision",), "dev", "formal-validation-release-revision"),
+        (("artifacts",), {}, "formal-validation-release-artifacts"),
+        (("artifacts", 0, "unexpected"), True, "formal-validation-release-artifact-shape"),
+    ],
+)
+def test_release_gate_rejects_remaining_integrity_mutations(keys, value, rule):
+    release = next(
+        item for item in copy_bundle(load_release_bundles, REPO_ROOT) if item.manifest["revision"] == "3.0.0"
+    )
+    target = release.manifest
+    for key in keys[:-1]:
+        target = target[key]
+    target[keys[-1]] = value
+    assert rule in {f.rule_id for f in validate_release_bundle(REPO_ROOT, release)}
+
+
+@pytest.mark.parametrize(
+    ("artifact", "field", "value", "rule"),
+    [
+        ("release", "revision", "99.0.0", "formal-validation-retest-release"),
+        ("protocol", "revision", "1.0.0", "formal-validation-retest-revision"),
+    ],
+)
+def test_retest_rejects_unsupported_release_or_protocol(artifact, field, value, rule):
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
+    target = release.manifest if artifact == "release" else protocol
+    target[field] = value
+    failures = validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis)
+    assert rule in {f.rule_id for f in failures}
+
+
+def test_retest_cannot_rewrite_a_historical_case():
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, REPO_ROOT)
+    corpus["cases"][0]["expected_outcome"] = "invented"
+    failures = validate_retest_bundle(REPO_ROOT, release, protocol, corpus, snapshot, analysis)
+    assert "formal-validation-historical-retention" in {f.rule_id for f in failures}
+
+
+def test_unsupported_case_cannot_acquire_a_fabricated_outcome():
+    manifest, protocol, corpus, snapshot, analysis = _bundle()
+    case = next(item for item in corpus["cases"] if item["replay_mode"] == "unsupported")
+    case["expected_outcome"] = "accepted"
+    failures = validate_bundle(REPO_ROOT, manifest, protocol, corpus, snapshot, analysis, replay_cases=False)
+    assert "formal-validation-unsupported-case" in {f.rule_id for f in failures}

--- a/implementations/python/tests/test_issue_1209_description_evidence.py
+++ b/implementations/python/tests/test_issue_1209_description_evidence.py
@@ -1,0 +1,166 @@
+"""Effective evidence claims must match the identity admitted by reporting."""
+
+from copy import deepcopy
+
+import pytest
+from raes_contracts.contracts.realization_descriptions import TypedRealizationDescriptionModel
+from raes_contracts.domain_profiles import (
+    DomainProfileAdmissionPolicyModel,
+    DomainProfileNamespaceAdmissionModel,
+    DomainProfileResolutionContextModel,
+)
+from raes_contracts.observation_demand import (
+    AchievedObservationValue,
+    ObservationBasis,
+    ObservationDemandResolution,
+    ObservationSelector,
+    realization_description_report,
+)
+from test_issue_1209_description_profiles import profiled_payload
+from test_issue_1209_descriptions import description_payload
+from test_issue_1212_runtime_boundaries import _demands
+
+
+def observed_payload(*, profiled=False):
+    payload = profiled_payload("experiment-run-v1") if profiled else description_payload()
+    payload["provenance"].update(
+        basis="observed", evidence_refs=[{"ref_kind": "evidence-record", "ref_id": "verified-evidence"}]
+    )
+    if profiled:
+        binding = payload["facts"][0]["profile_bindings"][0]
+        binding["provenance"].update(basis="observed", evidence_refs=["verified-evidence"])
+        binding["children"] = [deepcopy(binding)]
+        binding["children"][0]["binding_id"] = "nested-profile"
+    return payload
+
+
+def report(payload, *, protector=None):
+    selector = ObservationSelector(
+        semantic_scope="/nodes/a",
+        data_kind="field",
+        names=("family",),
+        coverage_profile="example-state/v1",
+        max_items=8,
+    )
+    return realization_description_report(
+        ObservationDemandResolution(_demands(selector, purpose="realization-description", required=True)),
+        {
+            selector.key: AchievedObservationValue(
+                TypedRealizationDescriptionModel.model_validate(payload),
+                ObservationBasis.OBSERVED,
+                evidence_ref="verified-evidence",
+            )
+        },
+        evidence_validator=lambda _key, value: value.evidence_ref == "verified-evidence",
+        protector=protector,
+        profile_context=DomainProfileResolutionContextModel(
+            namespace_admissions=(
+                DomainProfileNamespaceAdmissionModel(
+                    namespace="com.example.private", authority="urn:example:authority", trust_decision_id="admitted"
+                ),
+            ),
+            definitions=(),
+        ),
+        profile_policy=DomainProfileAdmissionPolicyModel(allow_opaque_exchange=True),
+    )
+
+
+@pytest.mark.parametrize("retain_coverage", [False, True])
+def test_projection_checks_effective_evidence_provenance(retain_coverage):
+    payload = observed_payload()
+    payload["facts"][0]["provenance"] = deepcopy(payload["provenance"])
+    if retain_coverage:
+        payload["coverage"][0]["provenance"] = deepcopy(payload["provenance"])
+    else:
+        payload["coverage"] = []
+    # This default applies only to facts that the requested projection removes.
+    payload["provenance"]["evidence_refs"][0]["ref_id"] = "unselected-evidence"
+    result = report(payload)[0].value
+    assert [fact.fact_id for fact in result.facts] == ["family"]
+    assert result.facts[0].provenance.evidence_refs[0].ref_id == "verified-evidence"
+    assert bool(result.coverage) is retain_coverage
+    if retain_coverage:
+        assert result.coverage[0].provenance.evidence_refs[0].ref_id == "verified-evidence"
+
+
+@pytest.mark.parametrize("inherited_claim", ["fact", "coverage"])
+def test_inherited_provenance_still_requires_verified_reference(inherited_claim):
+    payload = observed_payload()
+    payload["facts"][0]["provenance"] = deepcopy(payload["provenance"])
+    payload["coverage"][0]["provenance"] = deepcopy(payload["provenance"])
+    claim = payload["facts"][0] if inherited_claim == "fact" else payload["coverage"][0]
+    del claim["provenance"]
+    payload["provenance"]["evidence_refs"][0]["ref_id"] = "unverified-evidence"
+    with pytest.raises(ValueError, match="evidence"):
+        report(payload)
+
+
+@pytest.mark.parametrize("source", ["default", "fact", "coverage", "profiled-fact", "protection"])
+@pytest.mark.parametrize("qualifier", ["ref_kind", "ref_version", "ref_digest", "ref_path", "duplicate"])
+def test_reporting_rejects_unverified_reference_qualifiers(source, qualifier):
+    payload = observed_payload(profiled=source == "profiled-fact")
+
+    def forge(value):
+        provenance = value["provenance"]
+        if source in {"fact", "profiled-fact"}:
+            value["facts"][0]["provenance"] = deepcopy(provenance)
+            provenance = value["facts"][0]["provenance"]
+        elif source == "coverage":
+            value["coverage"][0]["provenance"] = deepcopy(provenance)
+            provenance = value["coverage"][0]["provenance"]
+        reference = provenance["evidence_refs"][0]
+        if qualifier == "duplicate":
+            provenance["evidence_refs"].append({**reference, "ref_version": "forged-version"})
+        else:
+            reference[qualifier] = {
+                "ref_kind": "other",
+                "ref_version": "forged-version",
+                "ref_digest": "sha256:" + "a" * 64,
+                "ref_path": "/unverified-evidence",
+            }[qualifier]
+
+    def protect(_key, achieved, _demand):
+        value = achieved.value.model_dump(mode="json")
+        forge(value)
+        return AchievedObservationValue(
+            TypedRealizationDescriptionModel.model_validate(value), achieved.basis, achieved.evidence_ref
+        )
+
+    # Pin the accepted identity, including the nested profile path, before forgery.
+    assert report(payload)[0].value.facts[0].fact_id == "family"
+    if source != "protection":
+        forge(payload)
+    with pytest.raises(ValueError, match="evidence"):
+        report(payload, protector=protect if source == "protection" else None)
+
+
+@pytest.mark.parametrize("after_protection", [False, True])
+def test_nested_profile_reference_cannot_escape_verified_fact(after_protection):
+    payload = observed_payload(profiled=True)
+    assert report(payload)[0].value.facts[0].profile_bindings[0].children
+
+    def forge(value):
+        value["facts"][0]["profile_bindings"][0]["children"][0]["provenance"]["evidence_refs"] = ["unverified"]
+
+    def protect(_key, achieved, _demand):
+        # Mutate the nested admitted model to exercise reporting's re-admission,
+        # without touching the fact or coverage reference that the verifier accepts.
+        nested = achieved.value.facts[0].profile_bindings[0].children[0]
+        object.__setattr__(nested.provenance, "evidence_refs", ("unverified",))
+        return achieved
+
+    if not after_protection:
+        forge(payload)
+    with pytest.raises(ValueError, match="description profile evidence must join its fact provenance"):
+        report(payload, protector=protect if after_protection else None)
+
+
+def test_nested_profile_evidence_is_checked_independently_by_report_join():
+    from raes_contracts.description_reporting import validate_description_evidence
+
+    value = TypedRealizationDescriptionModel.model_validate(observed_payload(profiled=True))
+    validate_description_evidence(value, ObservationBasis.OBSERVED, "verified-evidence")
+    nested = value.facts[0].profile_bindings[0].children[0]
+    object.__setattr__(nested.provenance, "evidence_refs", ("unverified",))
+    with pytest.raises(ValueError, match="typed description evidence must join the externally verified reference"):
+        validate_description_evidence(value, ObservationBasis.OBSERVED, "verified-evidence")

--- a/implementations/python/tests/test_issue_1209_description_lifecycle.py
+++ b/implementations/python/tests/test_issue_1209_description_lifecycle.py
@@ -1,0 +1,197 @@
+"""Generic backend callback and lifecycle tests; scenario values are fixture data."""
+
+from dataclasses import replace
+
+import pytest
+from raes_backend_stubs.stubs import create_stub_target
+from raes_contracts.contracts.realization_descriptions import TypedRealizationDescriptionModel
+from raes_contracts.observation_demand import (
+    AchievedObservationValue,
+    ObservationBasis,
+    ObservationLifecycleStage,
+    ObservationSelector,
+)
+from raes_contracts.planning import ProvisioningPlan
+from raes_runtime.control_plane import RuntimeControlPlane
+from raes_runtime.control_plane_store import InMemoryControlPlaneStore
+from test_issue_1209_descriptions import description_payload
+from test_issue_1212_runtime_boundaries import _demands, _runtime
+
+
+@pytest.mark.parametrize("retention", ["disable", "forbid", "require"])
+def test_typed_description_uses_existing_retention_and_recovery(retention):
+    selector = ObservationSelector(semantic_scope="/nodes/a", data_kind="field", names=("family",))
+    demands = _demands(
+        selector,
+        purpose="realization-description",
+        collection="require" if retention == "require" else "disable",
+        retention=retention,
+        export="forbid",
+        required=True,
+    )
+    calls = []
+    supplied = TypedRealizationDescriptionModel.model_validate(description_payload())
+
+    def describe(requested, *_):
+        calls.append(requested)
+        return AchievedObservationValue(supplied, ObservationBasis.BACKEND_SELECTED)
+
+    runtime = _runtime(selector, stages=frozenset({ObservationLifecycleStage.RETENTION}), describer=describe)
+    target = replace(create_stub_target(), observation_runtime=runtime)
+    store = InMemoryControlPlaneStore()
+    control = RuntimeControlPlane(target, store=store)
+    receipt = control.submit_provisioning(ProvisioningPlan(observation_demands=demands))
+    assert receipt.accepted
+    assert control.get_operation(receipt.operation_id).state.value == "succeeded"
+    assert calls == [selector]
+    recovered = RuntimeControlPlane(target, store=store).observation_execution(receipt.operation_id)
+    payload = store.load_records()[receipt.operation_id].result_payload
+    assert ("linux" in _stored_scalar_values(payload)) == (retention == "require")
+    if retention == "require":
+        description = recovered.realized_form_disclosures[0].typed_description
+        assert [fact.fact_id for fact in description.facts] == ["family"]
+        assert description.facts[0].value.value == "linux"
+        assert description.provenance.basis is ObservationBasis.BACKEND_SELECTED
+    else:
+        assert recovered.realized_form_disclosures == ()
+    assert calls == [selector]  # Recovery does not reacquire nonretained data.
+
+
+def test_five_selected_components_are_typed_fixture_data_without_collection():
+    selector = ObservationSelector(semantic_scope="/nodes", data_kind="field", names=("family",))
+    demands = _demands(
+        selector,
+        purpose="realization-description",
+        collection="require",
+        retention="require",
+        export="forbid",
+        required=True,
+    )
+    payload = description_payload()
+    payload["coverage"] = []
+    payload["facts"] = [
+        {
+            "fact_id": f"choice-{i}",
+            "subject": f"/nodes/n{i}/family",
+            "state": "known",
+            "value": {"kind": "literal", "origin": "backend", "value": choice},
+        }
+        for i, choice in enumerate(("linux", "kali", "abstract", "private-system", "linux"))
+    ]
+    selected = TypedRealizationDescriptionModel.model_validate(payload)
+    runtime = _runtime(
+        selector,
+        stages=frozenset({ObservationLifecycleStage.RETENTION}),
+        describer=lambda *_: AchievedObservationValue(selected, ObservationBasis.BACKEND_SELECTED),
+    )
+    target = replace(create_stub_target(), observation_runtime=runtime)
+    control = RuntimeControlPlane(target, store=InMemoryControlPlaneStore())
+    receipt = control.submit_provisioning(ProvisioningPlan(observation_demands=demands))
+    assert control.get_operation(receipt.operation_id).state.value == "succeeded"
+    execution = control.observation_execution(receipt.operation_id)
+    assert not execution.lifecycle.collected and not execution.lifecycle.exported
+    description = execution.realized_form_disclosures[0].typed_description
+    assert len(description.facts) == 5
+    assert [fact.value.value for fact in description.facts] == ["linux", "kali", "abstract", "private-system", "linux"]
+    assert all(fact.provenance is None for fact in description.facts)
+    assert description.provenance.evidence_refs == ()
+
+
+def test_protection_applies_to_typed_values_before_the_retention_transaction():
+    selector = ObservationSelector(semantic_scope="/nodes/a", data_kind="field", names=("family",))
+    demands = tuple(
+        demand.model_copy(update={"redaction": "scrub"})
+        for demand in _demands(
+            selector,
+            purpose="realization-description",
+            collection="require",
+            retention="require",
+            export="forbid",
+            required=True,
+        )
+    )
+    source = description_payload()
+    source["facts"][0]["value"]["value"] = "private-sentinel"
+    supplied = TypedRealizationDescriptionModel.model_validate(source)
+
+    def redact(values):
+        payload = values[0].model_dump(mode="json")
+        payload["facts"][0].update(state="withheld", value=None, limitations=["Selected policy withheld this value."])
+        return (TypedRealizationDescriptionModel.model_validate(payload),)
+
+    runtime = _runtime(
+        selector,
+        stages=frozenset({ObservationLifecycleStage.RETENTION}),
+        describer=lambda *_: AchievedObservationValue(supplied, ObservationBasis.BACKEND_SELECTED),
+        redactors={"scrub": redact},
+    )
+    target = replace(create_stub_target(), observation_runtime=runtime)
+    store = InMemoryControlPlaneStore()
+    control = RuntimeControlPlane(target, store=store)
+    receipt = control.submit_provisioning(ProvisioningPlan(observation_demands=demands))
+    assert control.get_operation(receipt.operation_id).state.value == "succeeded"
+    assert all(
+        "private-sentinel" not in _stored_scalar_values(record.result_payload)
+        for record in store.load_records().values()
+    )
+    recovered = control.observation_execution(receipt.operation_id).realized_form_disclosures[0].typed_description
+    assert recovered.facts[0].state == "withheld" and recovered.facts[0].value is None
+    assert supplied.facts[0].value.value == "private-sentinel"
+
+
+def test_typed_evidence_does_not_replace_required_emitted_bytes():
+    from raes_contracts.contracts import ExperimentEvidenceRecordModel
+    from raes_contracts.evidence_satisfaction import validate_experiment_run_evidence
+    from test_issue_1112_capture_admission import _evidence_bundle
+
+    task, run, spec, record, _payload = _evidence_bundle()
+    payload = record.model_dump(mode="json")
+    payload["typed_description"] = description_payload()
+    typed_record = ExperimentEvidenceRecordModel.model_validate(payload)
+    with pytest.raises(ValueError, match="concrete byte reader"):
+        validate_experiment_run_evidence(
+            task,
+            run,
+            capture_specs={spec.capture_spec_id: spec},
+            evidence_records={typed_record.evidence_record_id: typed_record},
+            artifact_readers={},
+        )
+
+
+def test_protection_cannot_restore_unrequested_fact_depth():
+    from raes_contracts.observation_demand import ObservationDemandResolution, realization_description_report
+
+    selector = ObservationSelector(semantic_scope="/nodes/a", data_kind="field", names=("family",))
+    demands = _demands(selector, purpose="realization-description", required=True)
+    source = description_payload()
+    source["facts"][1].update(
+        state="known", value={"kind": "literal", "origin": "backend", "value": "unrequested-private-detail"}
+    )
+    supplied = TypedRealizationDescriptionModel.model_validate(source)
+    value = AchievedObservationValue(supplied, ObservationBasis.BACKEND_SELECTED)
+    report = realization_description_report(
+        ObservationDemandResolution(demands), {selector.key: value}, protector=lambda *_: value
+    )
+    assert [fact.fact_id for fact in report[0].value.facts] == ["family"]
+    assert "unrequested-private-detail" not in report[0].value.model_dump_json()
+
+
+def test_requested_window_excludes_other_time_scope():
+    from raes_contracts.description_reporting import project_description
+
+    selector = ObservationSelector(
+        semantic_scope="/nodes/a", data_kind="field", names=("family",), window_refs=("another-window",)
+    )
+    source = TypedRealizationDescriptionModel.model_validate(description_payload())
+    assert project_description(source, selector, ObservationBasis.BACKEND_SELECTED).facts == ()
+
+
+def _stored_scalar_values(value):
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _stored_scalar_values(child)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            yield from _stored_scalar_values(child)
+    else:
+        yield value

--- a/implementations/python/tests/test_issue_1209_description_lifecycle.py
+++ b/implementations/python/tests/test_issue_1209_description_lifecycle.py
@@ -89,7 +89,8 @@ def test_five_selected_components_are_typed_fixture_data_without_collection():
     receipt = control.submit_provisioning(ProvisioningPlan(observation_demands=demands))
     assert control.get_operation(receipt.operation_id).state.value == "succeeded"
     execution = control.observation_execution(receipt.operation_id)
-    assert not execution.lifecycle.collected and not execution.lifecycle.exported
+    assert not execution.lifecycle.collected
+    assert not execution.lifecycle.exported
     description = execution.realized_form_disclosures[0].typed_description
     assert len(description.facts) == 5
     assert [fact.value.value for fact in description.facts] == ["linux", "kali", "abstract", "private-system", "linux"]
@@ -135,7 +136,8 @@ def test_protection_applies_to_typed_values_before_the_retention_transaction():
         for record in store.load_records().values()
     )
     recovered = control.observation_execution(receipt.operation_id).realized_form_disclosures[0].typed_description
-    assert recovered.facts[0].state == "withheld" and recovered.facts[0].value is None
+    assert recovered.facts[0].state == "withheld"
+    assert recovered.facts[0].value is None
     assert supplied.facts[0].value.value == "private-sentinel"
 
 
@@ -195,3 +197,55 @@ def _stored_scalar_values(value):
             yield from _stored_scalar_values(child)
     else:
         yield value
+
+
+@pytest.mark.parametrize("allow_opaque", [False, True])
+def test_runtime_description_profiles_preserve_explicit_host_policy(allow_opaque):
+    from raes_contracts.description_reporting import DescriptionProfileAdmission
+    from raes_contracts.domain_profiles import (
+        DomainProfileAdmissionPolicyModel,
+        DomainProfileNamespaceAdmissionModel,
+        DomainProfileResolutionContextModel,
+    )
+    from raes_runtime.observation_execution import ConfiguredObservationRuntime
+    from test_issue_1209_description_profiles import profiled_payload
+
+    selector = ObservationSelector(semantic_scope="/nodes/a", data_kind="field", names=("family",))
+    demands = _demands(
+        selector, purpose="realization-description", collection="require", retention="require", required=True
+    )
+    supplied = TypedRealizationDescriptionModel.model_validate(profiled_payload("experiment-run-v1"))
+    capabilities = _runtime(
+        selector, stages=frozenset({ObservationLifecycleStage.RETENTION}), describer=lambda *_: None
+    ).capabilities
+    runtime = ConfiguredObservationRuntime(
+        capabilities=capabilities,
+        describers={
+            "test-observation": lambda *_: AchievedObservationValue(supplied, ObservationBasis.BACKEND_SELECTED)
+        },
+        description_profiles=DescriptionProfileAdmission(
+            context=DomainProfileResolutionContextModel(
+                namespace_admissions=(
+                    DomainProfileNamespaceAdmissionModel(
+                        namespace="com.example.private",
+                        authority="urn:example:authority",
+                        trust_decision_id="local-admission",
+                    ),
+                ),
+                definitions=(),
+            ),
+            policy=DomainProfileAdmissionPolicyModel(allow_opaque_exchange=allow_opaque),
+        ),
+    )
+    target = replace(create_stub_target(), observation_runtime=runtime)
+    store = InMemoryControlPlaneStore()
+    control = RuntimeControlPlane(target, store=store)
+    receipt = control.submit_provisioning(ProvisioningPlan(observation_demands=demands))
+    assert receipt.accepted
+    assert control.get_operation(receipt.operation_id).state.value == ("succeeded" if allow_opaque else "failed")
+    if allow_opaque:
+        recovered = RuntimeControlPlane(target, store=store).observation_execution(receipt.operation_id)
+        assert (
+            recovered.realized_form_disclosures[0].typed_description.facts[0].profile_bindings
+            == supplied.facts[0].profile_bindings
+        )

--- a/implementations/python/tests/test_issue_1209_description_profiles.py
+++ b/implementations/python/tests/test_issue_1209_description_profiles.py
@@ -1,0 +1,144 @@
+"""Bindings cannot escape their carrier, selected fact or verified evidence basis."""
+
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+from raes_contracts.contracts import ExperimentEvidenceRecordModel, ExperimentRealizedFormDisclosureModel
+from raes_contracts.contracts.realization_descriptions import TypedRealizationDescriptionModel
+from raes_contracts.domain_profiles import DomainProfileBindingBasis, DomainProfileBindingUse
+from raes_contracts.observation_demand import (
+    AchievedObservationValue,
+    ObservationBasis,
+    ObservationDemandResolution,
+    ObservationSelector,
+    realization_description_report,
+)
+from test_issue_1202_domain_profiles import _binding, _definition
+from test_issue_1209_descriptions import description_payload, evidence_payload
+from test_issue_1212_runtime_boundaries import _demands
+
+
+def profiled_payload(host="experiment-evidence-record-v1"):
+    definition = _definition(namespace="com.example.private", authority="urn:example:authority", profile_id="detail")
+    binding = _binding(
+        definition,
+        value={"name": "profile-private-sentinel"},
+        use=DomainProfileBindingUse.OPAQUE_EXCHANGE,
+        basis=DomainProfileBindingBasis.BACKEND_SELECTED,
+    ).model_dump(mode="json")
+    binding["owner"].update(
+        owning_contract_id=host,
+        canonical_address="#/nodes/a/family",
+        lifecycle_phase="capture" if host == "experiment-evidence-record-v1" else "realization-description",
+    )
+    payload = description_payload()
+    payload["facts"][0]["profile_bindings"] = [binding]
+    return payload
+
+
+def carrier_payload(description, host):
+    if host == "experiment-evidence-record-v1":
+        return ExperimentEvidenceRecordModel, {**evidence_payload(), "typed_description": description}
+    return ExperimentRealizedFormDisclosureModel, {
+        "concern_id": "selection",
+        "concern_kind": "backend-selection",
+        "basis": "backend-realized",
+        "realized_by_ref": description["provenance"]["observer_ref"],
+        "realized_value_summary": "Requested detail",
+        "disclosure": "Selected detail",
+        "typed_description": description,
+    }
+
+
+@pytest.mark.parametrize("host", ["experiment-evidence-record-v1", "experiment-run-v1"])
+@pytest.mark.parametrize("change", ["address", "nested-address", "carrier", "phase", "nested-carrier", "nested-phase"])
+def test_profile_owners_are_bound_to_fact_and_lifecycle_carrier(host, change):
+    payload = profiled_payload(host)
+    binding = payload["facts"][0]["profile_bindings"][0]
+    if change.startswith("nested"):
+        binding["children"] = [deepcopy(binding)]
+        binding = binding["children"][0]
+        binding["binding_id"] = "child"
+    if change.endswith("address"):
+        binding["owner"]["canonical_address"] = "#/nodes/a/private"
+    elif change.endswith("carrier"):
+        binding["owner"]["owning_contract_id"] = (
+            "experiment-run-v1" if host == "experiment-evidence-record-v1" else "experiment-evidence-record-v1"
+        )
+    else:
+        binding["owner"]["lifecycle_phase"] = "authoring"
+    model, carrier = carrier_payload(payload, host)
+    with pytest.raises(ValidationError, match="profile.*owner"):
+        model.model_validate(carrier)
+
+
+@pytest.mark.parametrize("host", ["experiment-evidence-record-v1", "experiment-run-v1"])
+def test_valid_profile_owner_round_trips_in_its_carrier(host):
+    payload = profiled_payload(host)
+    model, carrier = carrier_payload(payload, host)
+    value = model.model_validate(carrier)
+    assert model.model_validate_json(value.model_dump_json()).typed_description == value.typed_description
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_backend_selected_fact_cannot_forge_observed_profile_basis(nested):
+    payload = profiled_payload()
+    binding = payload["facts"][0]["profile_bindings"][0]
+    if nested:
+        binding["children"] = [deepcopy(binding)]
+        binding = binding["children"][0]
+        binding["binding_id"] = "child"
+    binding["provenance"].update(basis="observed", evidence_refs=["forged-evidence"])
+    with pytest.raises(ValidationError, match="profile.*basis"):
+        TypedRealizationDescriptionModel.model_validate(payload)
+
+
+@pytest.mark.parametrize("basis", [ObservationBasis.OBSERVED, ObservationBasis.INDEPENDENTLY_VERIFIED])
+def test_profile_evidence_must_join_the_externally_verified_reference(basis):
+    from raes_contracts.domain_profiles import (
+        DomainProfileAdmissionPolicyModel,
+        DomainProfileNamespaceAdmissionModel,
+        DomainProfileResolutionContextModel,
+    )
+
+    payload = profiled_payload("experiment-run-v1")
+    payload["facts"] = payload["facts"][:1]
+    payload["coverage"] = []
+    payload["provenance"].update(
+        basis=basis.value, evidence_refs=[{"ref_kind": "evidence-record", "ref_id": "verified-evidence"}]
+    )
+    binding = payload["facts"][0]["profile_bindings"][0]
+    binding["provenance"].update(basis="observed", evidence_refs=["unverified-evidence"])
+    # Parser rejects a profile claim that does not join its descriptive provenance.
+    with pytest.raises(ValidationError, match="profile.*evidence"):
+        TypedRealizationDescriptionModel.model_validate(payload)
+    binding["provenance"]["evidence_refs"] = ["verified-evidence"]
+    value = TypedRealizationDescriptionModel.model_validate(payload)
+    selector = ObservationSelector(semantic_scope="/nodes/a", data_kind="field", names=("family",))
+    demands = _demands(selector, purpose="realization-description", required=True)
+    context = DomainProfileResolutionContextModel(
+        namespace_admissions=(
+            DomainProfileNamespaceAdmissionModel(
+                namespace="com.example.private", authority="urn:example:authority", trust_decision_id="admitted"
+            ),
+        ),
+        definitions=(),
+    )
+
+    def report(reference, validator):
+        return realization_description_report(
+            ObservationDemandResolution(demands),
+            {selector.key: AchievedObservationValue(value, basis, evidence_ref=reference)},
+            evidence_validator=validator,
+            profile_context=context,
+            profile_policy=DomainProfileAdmissionPolicyModel(allow_opaque_exchange=True),
+        )
+
+    with pytest.raises(ValueError, match="evidence"):
+        report("different-verified-reference", lambda *_: True)
+    with pytest.raises(ValueError, match="unsatisfied"):
+        report("verified-evidence", lambda *_: False)
+    assert report("verified-evidence", lambda *_: True)[0].value.facts[0].profile_bindings[
+        0
+    ].provenance.evidence_refs == ("verified-evidence",)

--- a/implementations/python/tests/test_issue_1209_description_relations.py
+++ b/implementations/python/tests/test_issue_1209_description_relations.py
@@ -1,0 +1,334 @@
+"""Coverage-aware comparison and explicit promotion into a new author artifact."""
+
+from copy import deepcopy
+
+import pytest
+from raes_contracts.canonical import canonical_json_digest
+from raes_contracts.contracts.realization_descriptions import TypedRealizationDescriptionModel
+from raes_contracts.realization_structure import (
+    RealizationClosure,
+    evaluate_realization_constraint,
+    normalize_realization_literal,
+)
+from test_issue_1209_descriptions import description_payload
+
+
+def authored_and_capture(*, value="linux", complete=False):
+    original = normalize_realization_literal(
+        {"nodes": {"a": {"family": "linux", "release": "1"}}},
+        semantic_profile="example-state/v1",
+        default_closure=RealizationClosure(posture="open", universe="node-fields/v1", profile="example-state/v1"),
+    ).document
+    payload = description_payload()
+    payload["authored_ref"]["ref_digest"] = canonical_json_digest(original.model_dump(mode="json"))
+    payload["facts"] = [payload["facts"][0]]
+    payload["facts"][0]["value"]["value"] = value
+    payload["coverage"][0]["fact_ids"] = ["family"]
+    if complete:
+        payload["facts"].append(
+            {
+                "fact_id": "release",
+                "subject": "/nodes/a/release",
+                "state": "known",
+                "value": {"kind": "literal", "value": "1", "origin": "backend"},
+            }
+        )
+        payload["coverage"][0].update(subject="", status="complete", recursive=True, fact_ids=["family", "release"])
+    return original, TypedRealizationDescriptionModel.model_validate(payload)
+
+
+def test_partial_match_is_unresolved_but_known_violation_is_detected():
+    from raes_contracts.description_projection import assess_realization_description
+
+    original, partial = authored_and_capture()
+    _, wrong = authored_and_capture(value="other")
+    assert assess_realization_description(partial, original).status.value == "unresolved"
+    assert assess_realization_description(wrong, original).status.value == "nonconformant"
+
+
+def test_complete_named_coverage_can_establish_conformance_without_changing_author():
+    from raes_contracts.description_projection import assess_realization_description
+
+    original, complete = authored_and_capture(complete=True)
+    before = deepcopy(original.model_dump(mode="json"))
+    assert assess_realization_description(complete, original).conformant
+    assert original.model_dump(mode="json") == before
+
+
+def test_conflicting_same_time_facts_survive_roundtrip_and_do_not_establish_truth():
+    from raes_contracts.description_projection import assess_realization_description
+
+    original, partial = authored_and_capture()
+    payload = partial.model_dump(mode="json")
+    competing = deepcopy(payload["facts"][0])
+    competing.update(fact_id="other-observer")
+    competing["value"]["value"] = "other"
+    competing["provenance"] = deepcopy(payload["provenance"])
+    competing["provenance"]["observer_ref"]["ref_id"] = "observer-2"
+    payload["facts"].append(competing)
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    restored = TypedRealizationDescriptionModel.model_validate_json(capture.model_dump_json())
+    result = assess_realization_description(restored, original)
+    assert len(restored.facts) == 2
+    assert result.status.value == "invalid"
+    assert result.diagnostics[0].code == "description.contradictory"
+    competing["provenance"]["recorded_at"] = "2026-09-12T11:00:00Z"
+    changed_over_time = TypedRealizationDescriptionModel.model_validate(payload)
+    assert assess_realization_description(changed_over_time, original).status.value == "nonconformant"
+
+
+def test_promotion_selects_only_named_facts_and_records_a_new_artifact():
+    from raes_contracts.description_promotion import promote_description
+
+    original, capture = authored_and_capture(complete=True)
+    before = capture.model_dump(mode="json")
+    result = promote_description(
+        capture,
+        original,
+        fact_ids=("family",),
+        actor="author-1",
+        decision_id="decision-1",
+        decided_at="2026-09-12T12:00:00Z",
+        target_id="new-request",
+        target_version="2",
+    )
+    assert result.constraints is not original
+    assert result.selected_fact_ids == ("family",)
+    assert result.target_ref.ref_id == "new-request"
+    assert result.decision_id == "decision-1" and result.actor == "author-1"
+    assert result.transformation.source_digest == canonical_json_digest(before)
+    assert result.transformation.target_digest == canonical_json_digest(result.constraints.model_dump(mode="json"))
+    assert evaluate_realization_constraint(
+        result.constraints, {"nodes": {"a": {"family": "linux", "release": "1"}}}
+    ).conformant
+    assert not evaluate_realization_constraint(
+        result.constraints, {"nodes": {"a": {"family": "linux", "release": "2"}}}
+    ).conformant
+    assert capture.model_dump(mode="json") == before
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ("other", "promotion cannot resolve conflicting assertions or weaken author constraints"),
+        (None, "promotion requires selected known supported scalar facts without limitations"),
+    ],
+)
+def test_promotion_refuses_conflicting_or_unobserved_facts(value, message):
+    from raes_contracts.description_promotion import promote_description
+
+    original, capture = authored_and_capture(value=value)
+    if value is None:
+        payload = capture.model_dump(mode="json")
+        payload["facts"][0].update(state="not-observed", value=None)
+        capture = TypedRealizationDescriptionModel.model_validate(payload)
+    with pytest.raises(ValueError, match=message):
+        promote_description(
+            capture,
+            original,
+            fact_ids=("family",),
+            actor="author-1",
+            decision_id="decision-1",
+            decided_at="2026-09-12T12:00:00Z",
+            target_id="new-request",
+            target_version="2",
+        )
+
+
+def test_known_absence_disproves_required_field_even_in_partial_capture():
+    from raes_contracts.description_projection import assess_realization_description
+
+    original, capture = authored_and_capture()
+    payload = capture.model_dump(mode="json")
+    payload["facts"][0].update(state="known-absent", value=None)
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    assert assess_realization_description(capture, original).status.value == "nonconformant"
+
+
+def test_promotion_cannot_add_a_field_under_closed_author_scope():
+    from raes_contracts.description_promotion import promote_description
+
+    original, capture = authored_and_capture()
+    original = original.model_copy(
+        update={
+            "default_closure": RealizationClosure(
+                posture="closed", universe="node-fields/v1", profile="example-state/v1"
+            )
+        }
+    )
+    payload = capture.model_dump(mode="json")
+    payload["authored_ref"]["ref_digest"] = canonical_json_digest(original.model_dump(mode="json"))
+    payload["facts"][0]["subject"] = "/nodes/a/extra"
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    with pytest.raises(
+        ValueError, match="promotion cannot resolve conflicting assertions or weaken author constraints"
+    ):
+        promote_description(
+            capture,
+            original,
+            fact_ids=("family",),
+            actor="author-1",
+            decision_id="decision-1",
+            decided_at="2026-09-12T12:00:00Z",
+            target_id="new-request",
+            target_version="2",
+        )
+
+
+def test_complete_coverage_cannot_combine_different_configuration_windows():
+    from raes_contracts.description_projection import assess_realization_description
+
+    original, capture = authored_and_capture(complete=True)
+    payload = capture.model_dump(mode="json")
+    payload["facts"][0]["provenance"] = {**payload["provenance"], "window_ref": "different-execution"}
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    assert assess_realization_description(capture, original).status.value == "unresolved"
+
+
+def test_nested_partial_record_still_exposes_a_known_scalar_violation():
+    from raes_contracts.description_projection import assess_realization_description
+
+    original, capture = authored_and_capture()
+    payload = capture.model_dump(mode="json")
+    payload["facts"][0].update(
+        subject="/nodes/a",
+        value={
+            "kind": "recursive-record",
+            "origin": "backend",
+            "fields": {"family": {"kind": "literal", "origin": "backend", "value": "other"}},
+        },
+    )
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    assert assess_realization_description(capture, original).status.value == "nonconformant"
+
+
+def test_mutated_overbudget_input_returns_limit_exceeded():
+    from raes_contracts.description_projection import assess_realization_description
+
+    original, capture = authored_and_capture()
+    capture = capture.model_copy(update={"limitations": ("x" * 5000,)})
+    assert assess_realization_description(capture, original).status.value == "limit-exceeded"
+
+
+def test_keyed_reordering_is_not_a_conflict_and_sequence_order_survives():
+    from raes_contracts.description_projection import description_conflict
+
+    payload = description_payload()
+
+    def member(identity):
+        return {
+            "identity": [identity],
+            "constraint": {
+                "kind": "recursive-record",
+                "origin": "backend",
+                "fields": {"id": {"kind": "literal", "origin": "backend", "value": identity}},
+            },
+        }
+
+    value = {
+        "kind": "keyed-collection",
+        "origin": "backend",
+        "collection_kind": "components",
+        "identity_fields": ["id"],
+        "members": [member("a"), member("b")],
+    }
+    payload["facts"] = [{"fact_id": "one", "subject": "/components", "state": "known", "value": value}]
+    second = deepcopy(payload["facts"][0])
+    second["fact_id"] = "two"
+    second["value"]["members"].reverse()
+    payload["facts"].append(second)
+    payload["coverage"] = []
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    assert description_conflict(capture) is None
+    sequence = {
+        "kind": "sequence",
+        "origin": "backend",
+        "items": [{"kind": "literal", "origin": "backend", "value": n} for n in (2, 1, 2)],
+    }
+    payload["facts"] = [{"fact_id": "trace", "subject": "/trace", "state": "known", "value": sequence}]
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    restored = TypedRealizationDescriptionModel.model_validate_json(capture.model_dump_json())
+    assert [item.value for item in restored.facts[0].value.items] == [2, 1, 2]
+
+
+def test_disjoint_partial_records_do_not_contradict_each_other():
+    from raes_contracts.description_projection import description_conflict
+
+    payload = description_payload()
+    payload["facts"] = [
+        {
+            "fact_id": field,
+            "subject": "/nodes/a",
+            "state": "known",
+            "value": {
+                "kind": "recursive-record",
+                "origin": "backend",
+                "fields": {field: {"kind": "literal", "origin": "backend", "value": value}},
+            },
+        }
+        for field, value in (("family", "linux"), ("release", "1"))
+    ]
+    payload["coverage"] = []
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    assert description_conflict(capture) is None
+
+
+def test_incompatible_assertions_in_one_window_are_not_hidden_by_another_window():
+    from raes_contracts.description_projection import description_conflict
+
+    payload = description_payload()
+    payload["coverage"] = []
+    source = payload["facts"][0]
+    other = deepcopy(source)
+    other.update(fact_id="other")
+    other["value"]["value"] = "other"
+    later = deepcopy(source)
+    later.update(fact_id="later", provenance={**payload["provenance"], "recorded_at": "2026-09-12T13:00:00Z"})
+    payload["facts"] = [source, other, later]
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    assert description_conflict(capture).status.value == "invalid"
+
+
+def test_overlapping_partial_records_require_reconciliation_before_projection():
+    from raes_contracts.description_projection import description_values
+
+    payload = description_payload()
+    payload["coverage"] = []
+    payload["facts"] = [
+        {
+            "fact_id": field,
+            "subject": "/nodes/a",
+            "state": "known",
+            "value": {
+                "kind": "recursive-record",
+                "origin": "backend",
+                "fields": {field: {"kind": "literal", "origin": "backend", "value": value}},
+            },
+        }
+        for field, value in (("family", "linux"), ("release", "1"))
+    ]
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    with pytest.raises(ValueError, match="reconciliation"):
+        description_values(capture.facts)
+
+
+def test_promotion_does_not_ignore_an_absent_ancestor():
+    from raes_contracts.description_promotion import promote_description
+
+    original, capture = authored_and_capture()
+    payload = capture.model_dump(mode="json")
+    payload["facts"].append({"fact_id": "absent-node", "subject": "/nodes/a", "state": "known-absent"})
+    capture = TypedRealizationDescriptionModel.model_validate(payload)
+    with pytest.raises(
+        ValueError, match="promotion cannot resolve conflicting assertions or weaken author constraints"
+    ):
+        promote_description(
+            capture,
+            original,
+            fact_ids=("family",),
+            actor="author",
+            decision_id="decision",
+            decided_at="2026-09-12T12:00:00Z",
+            target_id="new",
+            target_version="1",
+        )

--- a/implementations/python/tests/test_issue_1209_description_relations.py
+++ b/implementations/python/tests/test_issue_1209_description_relations.py
@@ -78,7 +78,7 @@ def test_conflicting_same_time_facts_survive_roundtrip_and_do_not_establish_trut
 
 
 def test_promotion_selects_only_named_facts_and_records_a_new_artifact():
-    from raes_contracts.description_promotion import promote_description
+    from raes_contracts.description_promotion import DescriptionPromotionDecision, promote_description
 
     original, capture = authored_and_capture(complete=True)
     before = capture.model_dump(mode="json")
@@ -86,16 +86,19 @@ def test_promotion_selects_only_named_facts_and_records_a_new_artifact():
         capture,
         original,
         fact_ids=("family",),
-        actor="author-1",
-        decision_id="decision-1",
-        decided_at="2026-09-12T12:00:00Z",
-        target_id="new-request",
-        target_version="2",
+        decision=DescriptionPromotionDecision(
+            actor="author-1",
+            decision_id="decision-1",
+            decided_at="2026-09-12T12:00:00Z",
+            target_id="new-request",
+            target_version="2",
+        ),
     )
     assert result.constraints is not original
     assert result.selected_fact_ids == ("family",)
     assert result.target_ref.ref_id == "new-request"
-    assert result.decision_id == "decision-1" and result.actor == "author-1"
+    assert result.decision_id == "decision-1"
+    assert result.actor == "author-1"
     assert result.transformation.source_digest == canonical_json_digest(before)
     assert result.transformation.target_digest == canonical_json_digest(result.constraints.model_dump(mode="json"))
     assert evaluate_realization_constraint(
@@ -115,23 +118,26 @@ def test_promotion_selects_only_named_facts_and_records_a_new_artifact():
     ],
 )
 def test_promotion_refuses_conflicting_or_unobserved_facts(value, message):
-    from raes_contracts.description_promotion import promote_description
+    from raes_contracts.description_promotion import DescriptionPromotionDecision, promote_description
 
     original, capture = authored_and_capture(value=value)
     if value is None:
         payload = capture.model_dump(mode="json")
         payload["facts"][0].update(state="not-observed", value=None)
         capture = TypedRealizationDescriptionModel.model_validate(payload)
+    decision = DescriptionPromotionDecision(
+        actor="author-1",
+        decision_id="decision-1",
+        decided_at="2026-09-12T12:00:00Z",
+        target_id="new-request",
+        target_version="2",
+    )
     with pytest.raises(ValueError, match=message):
         promote_description(
             capture,
             original,
             fact_ids=("family",),
-            actor="author-1",
-            decision_id="decision-1",
-            decided_at="2026-09-12T12:00:00Z",
-            target_id="new-request",
-            target_version="2",
+            decision=decision,
         )
 
 
@@ -146,7 +152,7 @@ def test_known_absence_disproves_required_field_even_in_partial_capture():
 
 
 def test_promotion_cannot_add_a_field_under_closed_author_scope():
-    from raes_contracts.description_promotion import promote_description
+    from raes_contracts.description_promotion import DescriptionPromotionDecision, promote_description
 
     original, capture = authored_and_capture()
     original = original.model_copy(
@@ -160,6 +166,13 @@ def test_promotion_cannot_add_a_field_under_closed_author_scope():
     payload["authored_ref"]["ref_digest"] = canonical_json_digest(original.model_dump(mode="json"))
     payload["facts"][0]["subject"] = "/nodes/a/extra"
     capture = TypedRealizationDescriptionModel.model_validate(payload)
+    decision = DescriptionPromotionDecision(
+        actor="author-1",
+        decision_id="decision-1",
+        decided_at="2026-09-12T12:00:00Z",
+        target_id="new-request",
+        target_version="2",
+    )
     with pytest.raises(
         ValueError, match="promotion cannot resolve conflicting assertions or weaken author constraints"
     ):
@@ -167,11 +180,7 @@ def test_promotion_cannot_add_a_field_under_closed_author_scope():
             capture,
             original,
             fact_ids=("family",),
-            actor="author-1",
-            decision_id="decision-1",
-            decided_at="2026-09-12T12:00:00Z",
-            target_id="new-request",
-            target_version="2",
+            decision=decision,
         )
 
 
@@ -313,12 +322,19 @@ def test_overlapping_partial_records_require_reconciliation_before_projection():
 
 
 def test_promotion_does_not_ignore_an_absent_ancestor():
-    from raes_contracts.description_promotion import promote_description
+    from raes_contracts.description_promotion import DescriptionPromotionDecision, promote_description
 
     original, capture = authored_and_capture()
     payload = capture.model_dump(mode="json")
     payload["facts"].append({"fact_id": "absent-node", "subject": "/nodes/a", "state": "known-absent"})
     capture = TypedRealizationDescriptionModel.model_validate(payload)
+    decision = DescriptionPromotionDecision(
+        actor="author",
+        decision_id="decision",
+        decided_at="2026-09-12T12:00:00Z",
+        target_id="new",
+        target_version="1",
+    )
     with pytest.raises(
         ValueError, match="promotion cannot resolve conflicting assertions or weaken author constraints"
     ):
@@ -326,9 +342,5 @@ def test_promotion_does_not_ignore_an_absent_ancestor():
             capture,
             original,
             fact_ids=("family",),
-            actor="author",
-            decision_id="decision",
-            decided_at="2026-09-12T12:00:00Z",
-            target_id="new",
-            target_version="1",
+            decision=decision,
         )

--- a/implementations/python/tests/test_issue_1209_description_review.py
+++ b/implementations/python/tests/test_issue_1209_description_review.py
@@ -1,0 +1,200 @@
+"""Regression evidence for the first partial-description review."""
+
+from copy import deepcopy
+
+import pytest
+from raes_contracts.canonical import canonical_json_digest
+from raes_contracts.contracts.realization_descriptions import TypedRealizationDescriptionModel
+from raes_contracts.description_projection import assess_realization_description, description_conflict
+from raes_contracts.observation_demand import (
+    AchievedObservationValue,
+    ObservationBasis,
+    ObservationDemandMode,
+    ObservationDemandResolution,
+    ObservationSelector,
+    realization_description_report,
+)
+from raes_contracts.realization_structure import RealizationClosure
+from test_issue_1209_description_relations import authored_and_capture
+from test_issue_1209_descriptions import description_payload
+from test_issue_1212_runtime_boundaries import _demands
+
+
+def test_literal_conflicts_preserve_integer_versus_float_type():
+    payload = description_payload()
+    payload["coverage"] = []
+    payload["facts"] = [
+        {
+            "fact_id": str(i),
+            "subject": "/value",
+            "state": "known",
+            "value": {"kind": "literal", "origin": "backend", "value": value},
+        }
+        for i, value in enumerate((1, 1.0))
+    ]
+    assert description_conflict(TypedRealizationDescriptionModel.model_validate(payload)).status.value == "invalid"
+
+
+def test_mixed_windows_do_not_hide_a_known_author_violation():
+    original, capture = authored_and_capture(value="wrong", complete=True)
+    payload = capture.model_dump(mode="json")
+    payload["facts"][1]["provenance"] = {**payload["provenance"], "window_ref": "another-window"}
+    assert (
+        assess_realization_description(TypedRealizationDescriptionModel.model_validate(payload), original).status.value
+        == "nonconformant"
+    )
+
+
+def test_conformance_rejects_coverage_of_wrong_kind():
+    original, capture = authored_and_capture(complete=True)
+    payload = capture.model_dump(mode="json")
+    payload["coverage"][0]["kind"] = "collection"
+    assert not assess_realization_description(
+        TypedRealizationDescriptionModel.model_validate(payload), original
+    ).conformant
+
+
+def test_conformance_requires_root_effective_coverage_universe():
+    original, capture = authored_and_capture(complete=True)
+    payload = capture.model_dump(mode="json")
+    original = original.model_copy(
+        update={
+            "root": original.root.model_copy(
+                update={
+                    "closure": RealizationClosure(posture="open", universe="root-fields/v1", profile="example-state/v1")
+                }
+            )
+        }
+    )
+    payload["authored_ref"]["ref_digest"] = canonical_json_digest(original.model_dump(mode="json"))
+    assert not assess_realization_description(
+        TypedRealizationDescriptionModel.model_validate(payload), original
+    ).conformant
+    payload["coverage"][0]["universe"] = "root-fields/v1"
+    assert assess_realization_description(TypedRealizationDescriptionModel.model_validate(payload), original).conformant
+
+
+def _report(payload, *, exhaustive=False, protector=None):
+    selector = ObservationSelector(
+        semantic_scope="/nodes/a",
+        data_kind="field",
+        names=("family",),
+        coverage_profile="example-state/v1",
+        max_items=8,
+    )
+    demands = _demands(selector, purpose="realization-description", required=True)
+    if exhaustive:
+        demands = tuple(d.model_copy(update={"mode": ObservationDemandMode.EXHAUSTIVE}) for d in demands)
+    value = AchievedObservationValue(
+        TypedRealizationDescriptionModel.model_validate(payload), ObservationBasis.BACKEND_SELECTED
+    )
+    return realization_description_report(
+        ObservationDemandResolution(demands), {selector.key: value}, protector=protector
+    )
+
+
+@pytest.mark.parametrize("change", ["missing", "partial", "profile", "kind", "broader", "excluded", "unknown"])
+def test_required_exhaustive_description_rejects_unmatched_coverage(change):
+    payload = description_payload()
+    payload["facts"] = payload["facts"][:1]
+    payload["coverage"][0].update(status="complete", recursive=True, fact_ids=["family"])
+    if change == "missing":
+        payload["coverage"] = []
+    elif change == "partial":
+        payload["coverage"][0]["status"] = "partial"
+    elif change == "profile":
+        payload["coverage"][0]["profile"] = "other/v1"
+    elif change == "kind":
+        payload["coverage"][0]["kind"] = "collection"
+    elif change == "broader":
+        payload["coverage"][0]["subject"] = "/nodes"
+    elif change == "unknown":
+        payload["facts"][0].update(state="not-observed", value=None)
+    else:
+        payload["coverage"][0]["limitations"] = ["A requested field was excluded."]
+    with pytest.raises(ValueError, match="coverage|unsatisfied"):
+        _report(payload, exhaustive=True)
+
+
+def test_exhaustive_description_accepts_matching_complete_coverage():
+    payload = description_payload()
+    payload["facts"] = payload["facts"][:1]
+    payload["coverage"][0].update(status="complete", recursive=True, fact_ids=["family"])
+    assert _report(payload, exhaustive=True)[0].value.coverage[0].status == "complete"
+
+
+def test_narrow_report_does_not_retain_a_broader_complete_claim():
+    payload = description_payload()
+    payload["facts"] = payload["facts"][:1]
+    payload["coverage"][0].update(subject="/nodes", status="complete", recursive=True, fact_ids=["family"])
+    assert _report(payload)[0].value.coverage == ()
+
+
+@pytest.mark.parametrize("carrier", ["mapping", "text"])
+def test_protector_cannot_escape_typed_projection_by_changing_carrier(carrier):
+    payload = description_payload()
+    restored = deepcopy(payload)
+    restored["facts"][1].update(
+        state="known", value={"kind": "literal", "origin": "backend", "value": "excluded-sentinel"}
+    )
+    raw = restored if carrier == "mapping" else repr(restored)
+    with pytest.raises(ValueError, match="typed description"):
+        _report(payload, protector=lambda *_: AchievedObservationValue(raw, ObservationBasis.BACKEND_SELECTED))
+
+
+def test_selector_exclusions_remove_complete_coverage_claims():
+    payload = description_payload()
+    payload["facts"] = payload["facts"][:1]
+    payload["coverage"][0].update(status="complete", recursive=True, fact_ids=["family"])
+    selector = ObservationSelector(
+        semantic_scope="/nodes/a",
+        excluded_scopes=("/nodes/a/private",),
+        data_kind="field",
+        names=("family",),
+        coverage_profile="example-state/v1",
+        max_items=8,
+    )
+    demands = tuple(
+        d.model_copy(update={"mode": ObservationDemandMode.EXHAUSTIVE})
+        for d in _demands(selector, purpose="realization-description", required=True)
+    )
+    value = AchievedObservationValue(
+        TypedRealizationDescriptionModel.model_validate(payload), ObservationBasis.BACKEND_SELECTED
+    )
+    with pytest.raises(ValueError, match="coverage|unsatisfied"):
+        realization_description_report(ObservationDemandResolution(demands), {selector.key: value})
+
+
+def test_coverage_cannot_claim_stronger_basis_than_the_report():
+    payload = description_payload()
+    payload["facts"] = payload["facts"][:1]
+    payload["coverage"][0].update(
+        status="complete",
+        recursive=True,
+        fact_ids=["family"],
+        provenance={
+            **payload["provenance"],
+            "basis": "observed",
+            "evidence_refs": [{"ref_kind": "other", "ref_id": "forged"}],
+        },
+    )
+    with pytest.raises(ValueError, match="basis|coverage|unsatisfied"):
+        _report(payload, exhaustive=True)
+
+
+def test_optional_exhaustive_description_omits_an_unsatisfied_result():
+    selector = ObservationSelector(
+        semantic_scope="/nodes/a",
+        data_kind="field",
+        names=("family",),
+        coverage_profile="example-state/v1",
+        max_items=8,
+    )
+    demands = tuple(
+        d.model_copy(update={"mode": ObservationDemandMode.EXHAUSTIVE})
+        for d in _demands(selector, purpose="realization-description", required=False)
+    )
+    value = AchievedObservationValue(
+        TypedRealizationDescriptionModel.model_validate(description_payload()), ObservationBasis.BACKEND_SELECTED
+    )
+    assert realization_description_report(ObservationDemandResolution(demands), {selector.key: value}) == ()

--- a/implementations/python/tests/test_issue_1209_description_review.py
+++ b/implementations/python/tests/test_issue_1209_description_review.py
@@ -161,8 +161,9 @@ def test_selector_exclusions_remove_complete_coverage_claims():
     value = AchievedObservationValue(
         TypedRealizationDescriptionModel.model_validate(payload), ObservationBasis.BACKEND_SELECTED
     )
+    resolution = ObservationDemandResolution(demands)
     with pytest.raises(ValueError, match="coverage|unsatisfied"):
-        realization_description_report(ObservationDemandResolution(demands), {selector.key: value})
+        realization_description_report(resolution, {selector.key: value})
 
 
 def test_coverage_cannot_claim_stronger_basis_than_the_report():

--- a/implementations/python/tests/test_issue_1209_descriptions.py
+++ b/implementations/python/tests/test_issue_1209_descriptions.py
@@ -1,0 +1,266 @@
+"""Partial descriptions retain knowledge without acquiring author authority."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from functools import cache
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from raes_contracts.contracts import ExperimentEvidenceRecordModel, ExperimentRealizedFormDisclosureModel
+
+
+def description_payload():
+    return {
+        "schema_version": "realization-description/v1",
+        "description_id": "capture-1",
+        "description_version": "1",
+        "semantic_profile": "example-state/v1",
+        "authored_ref": {
+            "ref_kind": "scenario",
+            "ref_id": "original",
+            "ref_version": "1",
+            "ref_digest": "sha256:" + "a" * 64,
+        },
+        "provenance": {
+            "observer_ref": {"ref_kind": "backend", "ref_id": "example", "ref_version": "1"},
+            "recorded_at": "2026-09-12T10:00:00Z",
+            "basis": "backend-selected",
+            "window_ref": "selection-1",
+        },
+        "facts": [
+            {
+                "fact_id": "family",
+                "subject": "/nodes/a/family",
+                "state": "known",
+                "value": {"kind": "literal", "value": "linux", "origin": "backend"},
+            },
+            {"fact_id": "release", "subject": "/nodes/a/release", "state": "not-observed"},
+            {"fact_id": "absent", "subject": "/nodes/a/optional", "state": "known-absent"},
+            {
+                "fact_id": "private",
+                "subject": "/nodes/a/private",
+                "state": "withheld",
+                "limitations": ["Not disclosed under the selected policy."],
+            },
+        ],
+        "coverage": [
+            {
+                "subject": "/nodes/a",
+                "kind": "field",
+                "universe": "node-fields/v1",
+                "profile": "example-state/v1",
+                "status": "partial",
+                "fact_ids": ["family", "release", "absent", "private"],
+            }
+        ],
+    }
+
+
+def evidence_payload():
+    return deepcopy(_committed_evidence_payload())
+
+
+@cache
+def _committed_evidence_payload():
+    root = Path(__file__).resolve().parents[3]
+    return json.loads(
+        (root / "contracts/fixtures/experiment-core/experiment-evidence-record-v1/valid/reference.json").read_text()
+    )
+
+
+def test_partial_description_round_trips_through_existing_evidence_envelope():
+    payload = evidence_payload()
+    payload["typed_description"] = description_payload()
+    record = ExperimentEvidenceRecordModel.model_validate(payload)
+    restored = ExperimentEvidenceRecordModel.model_validate_json(record.model_dump_json(exclude_none=True))
+    facts = {fact.fact_id: fact for fact in restored.typed_description.facts}
+    assert facts["family"].value.value == "linux"
+    assert facts["release"].state == "not-observed" and facts["release"].value is None
+    assert facts["absent"].state == "known-absent" and facts["absent"].value is None
+    assert facts["private"].state == "withheld" and facts["private"].limitations
+    assert restored.typed_description.provenance.basis.value == "backend-selected"
+    assert restored.typed_description.coverage[0].status == "partial"
+    assert restored.typed_description == record.typed_description
+
+
+@pytest.mark.parametrize("value", [None, False, 0, ""])
+def test_known_empty_values_are_not_missing(value):
+    payload = description_payload()
+    payload["facts"] = [
+        {
+            "fact_id": "known",
+            "subject": "/value",
+            "state": "known",
+            "value": {"kind": "literal", "value": value, "origin": "backend"},
+        }
+    ]
+    payload["coverage"] = []
+    disclosure = ExperimentRealizedFormDisclosureModel.model_validate(
+        {
+            "concern_id": "selection",
+            "concern_kind": "backend-selection",
+            "basis": "backend-realized",
+            "realized_by_ref": payload["provenance"]["observer_ref"],
+            "realized_value_summary": "Requested detail",
+            "disclosure": "Backend selection only.",
+            "typed_description": payload,
+        }
+    )
+    restored = ExperimentRealizedFormDisclosureModel.model_validate_json(disclosure.model_dump_json(exclude_none=True))
+    actual = restored.typed_description.facts[0].value.value
+    assert type(actual) is type(value) and actual == value
+
+
+@pytest.mark.parametrize("state", ["not-observed", "known-absent", "withheld", "contradictory", "not-applicable"])
+def test_nonknown_state_cannot_smuggle_a_value(state):
+    payload = evidence_payload()
+    description = description_payload()
+    description["facts"][0]["state"] = state
+    payload["typed_description"] = description
+    with pytest.raises(ValidationError, match="nonknown facts cannot carry values"):
+        ExperimentEvidenceRecordModel.model_validate(payload)
+
+
+def test_withheld_evidence_cannot_add_a_value_bearing_description():
+    payload = evidence_payload()
+    payload.update(
+        redaction_state="withheld", redaction_policy="private-policy", typed_description=description_payload()
+    )
+    payload["raw_content"]["loss_disclosure"] = "Withheld by policy."
+    with pytest.raises(ValidationError, match="withheld evidence cannot carry known descriptive values"):
+        ExperimentEvidenceRecordModel.model_validate(payload)
+
+
+def test_collection_identity_must_match_the_supplied_member():
+    payload = evidence_payload()
+    description = description_payload()
+    description["facts"][0]["value"] = {
+        "kind": "keyed-collection",
+        "origin": "backend",
+        "collection_kind": "components",
+        "identity_fields": ["id"],
+        "members": [
+            {
+                "identity": ["a"],
+                "constraint": {
+                    "kind": "recursive-record",
+                    "origin": "backend",
+                    "fields": {"id": {"kind": "literal", "origin": "backend", "value": "b"}},
+                },
+            }
+        ],
+    }
+    payload["typed_description"] = description
+    with pytest.raises(ValidationError, match="descriptive member identity"):
+        ExperimentEvidenceRecordModel.model_validate(payload)
+
+
+def test_private_offline_carriage_requires_explicit_host_admission_policy(monkeypatch):
+    from raes_contracts.contracts.realization_descriptions import TypedRealizationDescriptionModel
+    from raes_contracts.description_reporting import admit_description_profiles
+    from raes_contracts.domain_profiles import (
+        DomainProfileAdmissionPolicyModel,
+        DomainProfileBindingBasis,
+        DomainProfileBindingUse,
+        DomainProfileNamespaceAdmissionModel,
+        DomainProfileResolutionContextModel,
+    )
+    from test_issue_1202_domain_profiles import _binding, _definition
+
+    definition = _definition(
+        namespace="com.example.private", authority="urn:example:authority", profile_id="private-detail"
+    )
+    binding = _binding(
+        definition,
+        value={"name": "private-detail"},
+        use=DomainProfileBindingUse.OPAQUE_EXCHANGE,
+        basis=DomainProfileBindingBasis.BACKEND_SELECTED,
+    )
+    payload = description_payload()
+    binding_payload = binding.model_dump(mode="json")
+    binding_payload["owner"].update(
+        owning_contract_id="experiment-evidence-record-v1",
+        canonical_address="#/nodes/a/family",
+        lifecycle_phase="capture",
+    )
+    payload["facts"][0]["profile_bindings"] = [binding_payload]
+    description = TypedRealizationDescriptionModel.model_validate(payload)
+    import socket
+
+    monkeypatch.setattr(
+        socket, "create_connection", lambda *_args, **_kwargs: pytest.fail("profile admission attempted network access")
+    )
+    empty_context = DomainProfileResolutionContextModel(
+        namespace_admissions=(
+            DomainProfileNamespaceAdmissionModel(
+                namespace=definition.coordinate.namespace,
+                authority=definition.coordinate.authority,
+                trust_decision_id="local-admission",
+            ),
+        ),
+        definitions=(),
+    )
+    refused = admit_description_profiles(description, empty_context, policy=DomainProfileAdmissionPolicyModel())
+    assert not refused.admitted
+    admitted = admit_description_profiles(
+        description, empty_context, policy=DomainProfileAdmissionPolicyModel(allow_opaque_exchange=True)
+    )
+    assert admitted.admitted and admitted.results[0].opaque
+    restored = TypedRealizationDescriptionModel.model_validate_json(description.model_dump_json())
+    assert restored.facts[0].profile_bindings[0].coordinate == binding.coordinate
+    assert restored.facts[0].profile_bindings[0].value == {"name": "private-detail"}
+
+
+def test_description_json_ingress_rejects_duplicate_members_without_echoing_values():
+    from raes_contracts.description_reporting import parse_realization_description
+
+    source = '{"description_id":"operator-private-sentinel","description_id":"duplicate"}'
+    with pytest.raises(ValueError, match="duplicate JSON member") as error:
+        parse_realization_description(source)
+    assert "operator-private-sentinel" not in str(error.value)
+
+
+def test_published_envelope_schema_accepts_partial_description_and_rejects_false_state():
+    from jsonschema import Draft202012Validator
+
+    root = Path(__file__).resolve().parents[3]
+    schema = json.loads((root / "contracts/schemas/experiment-core/experiment-evidence-record-v1.json").read_text())
+    payload = evidence_payload()
+    payload["typed_description"] = description_payload()
+    validator = Draft202012Validator(schema)
+    assert not list(validator.iter_errors(payload))
+    payload["typed_description"]["facts"][0]["state"] = "withheld"
+    assert list(validator.iter_errors(payload))
+
+
+def test_excluded_descendants_cannot_leak_inside_a_selected_record():
+    from raes_contracts.contracts.realization_descriptions import TypedRealizationDescriptionModel
+    from raes_contracts.description_reporting import project_description
+    from raes_contracts.observation_demand import ObservationBasis, ObservationSelector
+
+    payload = description_payload()
+    payload["coverage"] = []
+    payload["facts"] = [
+        {
+            "fact_id": "node",
+            "subject": "/nodes/a",
+            "state": "known",
+            "value": {
+                "kind": "recursive-record",
+                "origin": "backend",
+                "fields": {"private": {"kind": "literal", "origin": "backend", "value": "private-sentinel"}},
+            },
+        }
+    ]
+    projected = project_description(
+        TypedRealizationDescriptionModel.model_validate(payload),
+        ObservationSelector(
+            semantic_scope="/nodes", data_kind="field", names=("a",), excluded_scopes=("/nodes/a/private",)
+        ),
+        ObservationBasis.BACKEND_SELECTED,
+    )
+    assert projected.facts == ()
+    assert "private-sentinel" not in projected.model_dump_json()

--- a/implementations/python/tests/test_issue_1209_descriptions.py
+++ b/implementations/python/tests/test_issue_1209_descriptions.py
@@ -78,9 +78,12 @@ def test_partial_description_round_trips_through_existing_evidence_envelope():
     restored = ExperimentEvidenceRecordModel.model_validate_json(record.model_dump_json(exclude_none=True))
     facts = {fact.fact_id: fact for fact in restored.typed_description.facts}
     assert facts["family"].value.value == "linux"
-    assert facts["release"].state == "not-observed" and facts["release"].value is None
-    assert facts["absent"].state == "known-absent" and facts["absent"].value is None
-    assert facts["private"].state == "withheld" and facts["private"].limitations
+    assert facts["release"].state == "not-observed"
+    assert facts["release"].value is None
+    assert facts["absent"].state == "known-absent"
+    assert facts["absent"].value is None
+    assert facts["private"].state == "withheld"
+    assert facts["private"].limitations
     assert restored.typed_description.provenance.basis.value == "backend-selected"
     assert restored.typed_description.coverage[0].status == "partial"
     assert restored.typed_description == record.typed_description
@@ -111,7 +114,8 @@ def test_known_empty_values_are_not_missing(value):
     )
     restored = ExperimentRealizedFormDisclosureModel.model_validate_json(disclosure.model_dump_json(exclude_none=True))
     actual = restored.typed_description.facts[0].value.value
-    assert type(actual) is type(value) and actual == value
+    assert type(actual) is type(value)
+    assert actual == value
 
 
 @pytest.mark.parametrize("state", ["not-observed", "known-absent", "withheld", "contradictory", "not-applicable"])
@@ -208,7 +212,8 @@ def test_private_offline_carriage_requires_explicit_host_admission_policy(monkey
     admitted = admit_description_profiles(
         description, empty_context, policy=DomainProfileAdmissionPolicyModel(allow_opaque_exchange=True)
     )
-    assert admitted.admitted and admitted.results[0].opaque
+    assert admitted.admitted
+    assert admitted.results[0].opaque
     restored = TypedRealizationDescriptionModel.model_validate_json(description.model_dump_json())
     assert restored.facts[0].profile_bindings[0].coordinate == binding.coordinate
     assert restored.facts[0].profile_bindings[0].value == {"name": "private-detail"}

--- a/implementations/python/tests/test_issue_1209_policy_ownership.py
+++ b/implementations/python/tests/test_issue_1209_policy_ownership.py
@@ -1,0 +1,31 @@
+"""Description semantics own contracts and evidence, without owning backends."""
+
+from pathlib import Path
+
+import yaml
+from tools.policy.requirement_governance import _check_path_ownership, match_phase
+
+
+def test_description_semantics_ownership_includes_contracts_and_excludes_backends():
+    root = Path(__file__).resolve().parents[3]
+    policy = yaml.safe_load((root / "tools/policy/requirement_order.yaml").read_text())
+    phase = match_phase(policy, "SEM-218")
+    paths = [
+        "implementations/python/packages/raes_contracts/contracts/realization_descriptions.py",
+        "implementations/python/packages/raes_runtime/observation_results.py",
+        "contracts/schemas/experiment-core/experiment-evidence-record-v1.json",
+        "contracts/schema-publication/entries/experiment-run-v1.json",
+        "contracts/fixtures/experiment-core/experiment-evidence-record-v1/valid/partial-description.json",
+        "docs/requirements/SEM-218/requirement.md",
+        "docs/decisions/issue-1209-clause-mapping.md",
+        "specs/sdl/recursive-realization-constraints.md",
+    ]
+    assert _check_path_ownership(policy, phase, paths) == []
+    forbidden = [
+        "implementations/python/packages/raes_reference_backend/target.py",
+        "implementations/python/packages/raes_backend_stubs/stubs.py",
+    ]
+    failures = _check_path_ownership(policy, phase, forbidden)
+    assert {(failure.rule_id, failure.path) for failure in failures} == {
+        ("requirement-ownership-mismatch", path) for path in forbidden
+    }

--- a/implementations/python/tests/test_issue_989_versioned_evidence.py
+++ b/implementations/python/tests/test_issue_989_versioned_evidence.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
+from evidence_test_fixtures import copy_bundle
 
 ROOT = Path(__file__).resolve().parents[3]
 
@@ -17,7 +18,7 @@ def test_current_compile_replay_hashes_complete_capture_dimension():
     from tools.formal_semantic_validation._replay import _compiled_case_digest, _migration_policy_for_case
     from tools.formal_semantic_validation._shape import _digest
 
-    _, _, corpus, _, _ = load_retest_bundle(ROOT)
+    _, _, corpus, _, _ = copy_bundle(load_retest_bundle, ROOT)
     case = next(c for c in corpus["cases"] if c["case_id"] == "compile-repeatability-control")
     path = ROOT / case["fixture_path"]
     scenario = parse_sdl_file(path, migration_policy=_migration_policy_for_case(ROOT, case, path))
@@ -42,7 +43,7 @@ def test_historical_integrated_release_does_not_execute_current_code(monkeypatch
     from tools.formal_semantic_validation import _production, _releases, _retest
     from tools.formal_semantic_validation._loading import load_release_bundles
 
-    release = next(r for r in load_release_bundles(ROOT) if r.manifest["revision"] == "3.0.0")
+    release = next(r for r in copy_bundle(load_release_bundles, ROOT) if r.manifest["revision"] == "3.0.0")
 
     def forbidden(*args, **kwargs):
         raise AssertionError("historical observations are not current-code evidence")
@@ -57,8 +58,8 @@ def test_latest_current_release_is_versioned_and_strict(monkeypatch):
     from tools.formal_semantic_validation._loading import load_retest_bundle
     from tools.formal_semantic_validation._releases import validate_retest_bundle
 
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(ROOT)
-    assert release.manifest["revision"] == "9.0.0"
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, ROOT)
+    assert release.manifest["revision"] == "10.0.0"
     original = _retest.replay_case
 
     def changed_result(root, case):
@@ -76,7 +77,7 @@ def test_current_release_requires_truthful_implementation_provenance():
     from tools.formal_semantic_validation._loading import load_retest_bundle
     from tools.formal_semantic_validation._releases import validate_retest_bundle
 
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, ROOT)
     snapshot = deepcopy(snapshot)
     assert "source_state" in snapshot
     snapshot["source_state"]["implementation_digest"] = "0" * 64
@@ -93,7 +94,7 @@ def test_current_production_evidence_replay_failure_is_not_hidden(monkeypatch):
         raise ValueError("seeded production replay failure")
 
     monkeypatch.setattr(satisfiability, "replay_satisfiability_evidence", fail)
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, ROOT)
     failures = validate_retest_bundle(ROOT, release, protocol, corpus, snapshot, analysis)
     assert "formal-validation-production-replay" in {f.rule_id for f in failures}
 
@@ -101,8 +102,8 @@ def test_current_production_evidence_replay_failure_is_not_hidden(monkeypatch):
 def test_specification_current_capture_does_not_accept_old_artifact_digest():
     from tools.check_specification_coverage import load_bundle, validate_bundle
 
-    manifest, protocol, snapshot, analysis = load_bundle(ROOT)
-    assert manifest["revision"] == "7.0.0"
+    manifest, protocol, snapshot, analysis = copy_bundle(load_bundle, ROOT)
+    assert manifest["revision"] == "8.0.0"
     snapshot = deepcopy(snapshot)
     artifact = next(a for a in snapshot["artifacts"] if a["artifact_id"] == "port-range-sdl")
     artifact["sha256"] = "a27c7a64e0c5c618fadaccafdf1a4e71600170a8b77b983190822b5141f00dec"
@@ -114,7 +115,7 @@ def test_historical_specification_evidence_is_integrity_checked_without_executio
     from tools import check_specification_coverage as coverage
     from tools.specification_coverage import _artifacts
 
-    manifest, protocol, snapshot, analysis = coverage.load_bundles(ROOT)[0]
+    manifest, protocol, snapshot, analysis = copy_bundle(coverage.load_bundles, ROOT)[0]
 
     def forbidden(*args, **kwargs):
         raise AssertionError("must not execute an archived artifact on current code")
@@ -127,7 +128,7 @@ def test_historical_specification_evidence_is_integrity_checked_without_executio
 def test_historical_specification_archive_pin_tampering_fails(value):
     from tools import check_specification_coverage as coverage
 
-    manifest, protocol, snapshot, analysis = coverage.load_bundles(ROOT)[0]
+    manifest, protocol, snapshot, analysis = copy_bundle(coverage.load_bundles, ROOT)[0]
     snapshot = deepcopy(snapshot)
     snapshot["artifacts"][0]["sha256"] = value
     failures = coverage.validate_historical_bundle(ROOT, protocol, snapshot, analysis)
@@ -164,7 +165,7 @@ def test_current_formal_release_cannot_request_historical_validation():
     from tools.formal_semantic_validation._loading import load_retest_bundle
     from tools.formal_semantic_validation._releases import validate_retest_bundle
 
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, ROOT)
     failures = validate_retest_bundle(ROOT, release, protocol, corpus, snapshot, analysis, replay_current=False)
     assert {f.rule_id for f in failures} == {"formal-validation-current-replay-required"}
 
@@ -198,7 +199,7 @@ def test_historical_supplement_never_runs_current_analyzer(monkeypatch):
         raise AssertionError("historical supplement must not claim current execution")
 
     monkeypatch.setattr(satisfiability, "analyze_scenario_file", forbidden)
-    release = next(r for r in load_release_bundles(ROOT) if r.manifest["revision"] == "2.0.0")
+    release = next(r for r in copy_bundle(load_release_bundles, ROOT) if r.manifest["revision"] == "2.0.0")
     assert validate_release_bundle(ROOT, release) == []
 
 
@@ -215,7 +216,7 @@ def test_current_cli_result_drift_is_rejected(monkeypatch):
         return payload
 
     monkeypatch.setattr(_production, "_run_production_evidence_cli", changed_cli)
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, ROOT)
     failures = validate_retest_bundle(ROOT, release, protocol, corpus, snapshot, analysis)
     assert "formal-validation-production-evidence-join" in {f.rule_id for f in failures}
 
@@ -235,7 +236,7 @@ def test_current_cli_must_emit_the_complete_pinned_payload(monkeypatch):
         return payload
 
     monkeypatch.setattr(_production, "_run_production_evidence_cli", omit_default)
-    release, protocol, corpus, snapshot, analysis = load_retest_bundle(ROOT)
+    release, protocol, corpus, snapshot, analysis = copy_bundle(load_retest_bundle, ROOT)
     failures = validate_retest_bundle(ROOT, release, protocol, corpus, snapshot, analysis)
     assert "formal-validation-production-evidence-join" in {f.rule_id for f in failures}
 
@@ -253,7 +254,7 @@ def test_archive_content_tampering_fails_even_when_manifest_pin_is_unchanged(mon
         return payload
 
     monkeypatch.setattr(_artifacts, "load_bounded_json_object", changed_archive)
-    _, protocol, snapshot, analysis = coverage.load_bundles(ROOT)[0]
+    _, protocol, snapshot, analysis = copy_bundle(coverage.load_bundles, ROOT)[0]
     failures = coverage.validate_historical_bundle(ROOT, protocol, snapshot, analysis)
     assert "specification-coverage-artifact-digest" in {f.rule_id for f in failures}
 
@@ -266,9 +267,9 @@ def test_no_capture_can_be_silently_dropped(monkeypatch, family, removed):
 
     module = _loading if family == "formal" else check_specification_coverage
     revisions = (
-        ["1.0.0", "1.1.0", "1.2.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0"]
+        ["1.0.0", "1.1.0", "1.2.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0", "10.0.0"]
         if family == "formal"
-        else ["1.0.0", "1.1.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0"]
+        else ["1.0.0", "1.1.0", "2.0.0", "3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0"]
     )
     revisions.pop(-1 if removed == "current" else 0)
     monkeypatch.setattr(
@@ -285,7 +286,7 @@ def test_no_capture_can_be_silently_dropped(monkeypatch, family, removed):
 def test_current_coverage_requires_exact_baseline_deviations(change):
     from tools.check_specification_coverage import load_bundle, validate_bundle
 
-    _, protocol, snapshot, analysis = load_bundle(ROOT)
+    _, protocol, snapshot, analysis = copy_bundle(load_bundle, ROOT)
     if change == "missing":
         snapshot["deviations"].pop()
     elif change == "old_digest":
@@ -302,7 +303,7 @@ def test_current_coverage_requires_exact_baseline_deviations(change):
 def test_current_coverage_preserves_untested_slots_without_claiming_capability_absence():
     from tools.check_specification_coverage import load_bundle
 
-    _, protocol, snapshot, analysis = load_bundle(ROOT)
+    _, protocol, snapshot, analysis = copy_bundle(load_bundle, ROOT)
     missing = [item for item in snapshot["concept_results"] if item["classification"] == "missing"]
     assert len(snapshot["concept_results"]) == len(protocol["concepts"]) == 16
     assert len(missing) == 3
@@ -316,7 +317,7 @@ def test_historical_archive_does_not_require_a_live_source_file(tmp_path):
     from tools.check_specification_coverage import load_bundles
     from tools.specification_coverage._artifacts import _validate_artifacts
 
-    _, _, snapshot, _ = load_bundles(ROOT)[0]
+    _, _, snapshot, _ = copy_bundle(load_bundles, ROOT)[0]
     archive = Path("docs/research/specification-coverage/historical-artifacts")
     shutil.copytree(ROOT / archive, tmp_path / archive)
     assert all(not (tmp_path / item["path"]).exists() for item in snapshot["artifacts"])

--- a/implementations/python/tests/test_specification_coverage.py
+++ b/implementations/python/tests/test_specification_coverage.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from copy import deepcopy
 from pathlib import Path
 
+import pytest
+from evidence_test_fixtures import copy_bundle
 from tools.check_specification_coverage import (
     EXPECTED_CLASSIFICATIONS,
     EXPECTED_STRATA,
@@ -23,7 +25,7 @@ def _rule_ids(failures: list[object]) -> set[str]:
 
 
 def _bundle() -> tuple[dict, dict, dict, dict]:
-    manifest, protocol, snapshot, analysis = load_bundle(REPO_ROOT)
+    manifest, protocol, snapshot, analysis = copy_bundle(load_bundle, REPO_ROOT)
     return (
         deepcopy(manifest),
         deepcopy(protocol),
@@ -47,10 +49,10 @@ def test_current_bundle_records_reproducible_and_honest_results() -> None:
 
 
 def test_immutable_bundle_index_preserves_concurrent_captures() -> None:
-    bundles = load_bundles(REPO_ROOT)
+    bundles = copy_bundle(load_bundles, REPO_ROOT)
     assert {manifest["revision"] for manifest, *_rest in bundles} >= {"1.0.0", "1.1.0"}
-    manifest, *_rest = load_bundle(REPO_ROOT)
-    assert manifest["revision"] == "7.0.0"
+    manifest, *_rest = copy_bundle(load_bundle, REPO_ROOT)
+    assert manifest["revision"] == "8.0.0"
 
 
 def test_gate_rejects_missing_strata_and_composite_concepts() -> None:
@@ -182,7 +184,7 @@ def test_gate_rejects_invalid_implementation_identity_and_analysis_join() -> Non
 
 
 def test_historical_implementation_digest_does_not_bind_the_live_checkout() -> None:
-    _, protocol, snapshot, analysis = deepcopy(load_bundles(REPO_ROOT)[0])
+    _, protocol, snapshot, analysis = deepcopy(copy_bundle(load_bundles, REPO_ROOT)[0])
     surfaces = snapshot.get("implementation_surfaces")
     assert isinstance(surfaces, list) and surfaces
     surfaces[0]["content_sha256"] = "f" * 64
@@ -197,3 +199,34 @@ def test_current_implementation_surface_digest_binds_live_checkout() -> None:
     snapshot["implementation_surfaces"][0]["content_sha256"] = "f" * 64
     failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
     assert "specification-coverage-implementation-identity" in _rule_ids(failures)
+
+
+@pytest.mark.parametrize(
+    ("artifact", "keys", "value", "rule"),
+    [
+        ("protocol", ("title",), "", "specification-coverage-protocol-shape"),
+        ("protocol", ("classification_rules",), {}, "specification-coverage-classifications"),
+        ("protocol", ("artifact_stages",), [{"stage_id": "incomplete"}], "specification-coverage-stage-catalog"),
+        ("protocol", ("carriers", 0, "carrier_id"), "", "specification-coverage-carriers"),
+        ("protocol", ("concepts", 0, "request_id"), "unknown", "specification-coverage-concepts"),
+        (
+            "protocol",
+            ("execution_rules", "normal_execution_network_access"),
+            True,
+            "specification-coverage-execution-rules",
+        ),
+        ("snapshot", ("raes_revision",), "dev", "specification-coverage-snapshot-shape"),
+        ("snapshot", ("execution_status",), "incomplete", "specification-coverage-snapshot-status"),
+        ("snapshot", ("artifacts", 0, "artifact_id"), "", "specification-coverage-artifacts"),
+        ("analysis", ("protocol_revision",), "stale", "specification-coverage-analysis-join"),
+        ("analysis", ("classification_counts",), {}, "specification-coverage-analysis-shape"),
+    ],
+)
+def test_gate_rejects_each_remaining_integrity_rule(artifact, keys, value, rule):
+    _, protocol, snapshot, analysis = _bundle()
+    target = {"protocol": protocol, "snapshot": snapshot, "analysis": analysis}[artifact]
+    for key in keys[:-1]:
+        target = target[key]
+    target[keys[-1]] = value
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+    assert rule in _rule_ids(failures)

--- a/implementations/python/tests/test_specification_coverage_units.py
+++ b/implementations/python/tests/test_specification_coverage_units.py
@@ -1,0 +1,141 @@
+"""Independent arithmetic oracles and small evidence-validator fixtures."""
+
+from hashlib import sha256
+
+import pytest
+from evidence_test_fixtures import copy_bundle
+from tools.specification_coverage import _artifacts, _protocol
+from tools.specification_coverage._analysis import recompute_analysis
+
+
+def test_cached_evidence_is_loaded_once_and_copied_per_test(tmp_path):
+    calls = []
+
+    def load(root):
+        calls.append(root)
+        return {"observations": [{"outcome": "accepted"}]}
+
+    first = copy_bundle(load, tmp_path)
+    first["observations"][0]["outcome"] = "mutated"
+    assert copy_bundle(load, tmp_path) == {"observations": [{"outcome": "accepted"}]}
+    assert calls == [tmp_path]
+
+
+def analysis_inputs(rows):
+    concepts, results = [], []
+    for index, (classification, load_bearing, outcome) in enumerate(rows):
+        concept_id = f"concept-{index}"
+        concepts.append(
+            {"concept_id": concept_id, "load_bearing": load_bearing, "expected_classification": classification}
+        )
+        results.append(
+            {
+                "concept_id": concept_id,
+                "classification": classification,
+                "stage_results": [{"outcome": outcome}],
+                "backend_vocabulary_occurrences": [],
+            }
+        )
+    return {
+        "concepts": concepts,
+        "requests": [{"request_id": "request", "concept_ids": [item["concept_id"] for item in concepts]}],
+    }, {"execution_status": "complete", "concept_results": results}
+
+
+def test_analysis_arithmetic_has_an_independent_mixed_classification_oracle():
+    protocol, snapshot = analysis_inputs(
+        [
+            ("directly-expressible", True, "passed"),
+            ("profile-or-manifest-constraint", True, "passed"),
+            ("profile-or-manifest-constraint", True, "failed"),
+            ("missing", True, "unsupported"),
+            ("deliberately-backend-specific", False, "not_applicable"),
+            ("directly-expressible", False, "passed"),
+        ]
+    )
+    actual = recompute_analysis(protocol, snapshot, {})
+    assert actual["classification_counts"] == {
+        "directly-expressible": 2,
+        "profile-or-manifest-constraint": 2,
+        "deliberately-backend-specific": 1,
+        "missing": 1,
+    }
+    assert actual["load_bearing_results"] == {"total": 4, "passed": 2, "failed": 1, "missing": 1}
+    assert actual["request_results"] == [
+        {"request_id": "request", "status": "refuted", "concept_count": 6, "missing_count": 1, "failed_stage_count": 1}
+    ]
+    assert actual["evidence_status"] == "refuted"
+
+
+@pytest.mark.parametrize(
+    ("classification", "outcome", "expected"),
+    [
+        ("directly-expressible", "passed", "demonstrated"),
+        ("directly-expressible", "failed", "partial"),
+        ("missing", "unsupported", "partial"),
+    ],
+)
+def test_noncritical_evidence_status_is_derived_independently(classification, outcome, expected):
+    protocol, snapshot = analysis_inputs([(classification, False, outcome)])
+    result = recompute_analysis(protocol, snapshot, {"evidence_status": "invented"})
+    assert result["evidence_status"] == expected
+    assert result["request_results"][0]["status"] == expected
+    assert result["load_bearing_results"] == {"total": 0, "passed": 0, "failed": 0, "missing": 0}
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "rule", "message"),
+    [
+        ("stratum_id", "unknown", "specification-coverage-sources", "source has unknown stratum"),
+        ("artifact_path", "../outside", "specification-coverage-source-path", "source path is unsafe or missing"),
+        ("content_sha256", "0" * 64, "specification-coverage-source-digest", "source digest is stale"),
+    ],
+)
+def test_synthetic_source_integrity(tmp_path, field, value, rule, message):
+    (tmp_path / "source.txt").write_bytes(b"source")
+    source = {
+        "source_id": "source",
+        "stratum_id": "study",
+        "locator": "https://example.invalid/study",
+        "artifact_path": "source.txt",
+        "content_sha256": sha256(b"source").hexdigest(),
+    }
+    failures = []
+    _protocol._source_entry_failures(tmp_path, source, {"study"}, failures, "protocol.json")
+    assert failures == []
+    source[field] = value
+    _protocol._source_entry_failures(tmp_path, source, {"study"}, failures, "protocol.json")
+    assert [(f.rule_id, f.message) for f in failures] == [(rule, message)]
+
+
+def test_synthetic_request_rejects_a_source_from_another_stratum():
+    request = {"source_refs": ["source"], "stratum_id": "study"}
+    sources = [{"source_id": "source", "stratum_id": "study"}]
+    failures = []
+    _protocol._request_entry_failures(request, sources, {"source"}, {"study", "survey"}, failures, "protocol.json")
+    assert failures == []
+    sources[0]["stratum_id"] = "survey"
+    _protocol._request_entry_failures(request, sources, {"source"}, {"study", "survey"}, failures, "protocol.json")
+    assert [(f.rule_id, f.message) for f in failures] == [
+        ("specification-coverage-requests", "request/source stratum mismatch")
+    ]
+
+
+@pytest.mark.parametrize("error", [OSError, ValueError, TypeError])
+def test_artifact_execution_errors_become_explicit_failures(tmp_path, monkeypatch, error):
+    def fail(*_args):
+        raise error("seeded replay failure")
+
+    monkeypatch.setattr(_artifacts, "_execute_artifact", fail)
+    failures, executed = [], {}
+    _artifacts._record_artifact_execution(
+        tmp_path, {"artifact_id": "artifact", "kind": "sdl"}, "input.yaml", tmp_path / "input.yaml", executed, failures
+    )
+    assert executed == {}
+    assert [(f.rule_id, f.message, f.path) for f in failures] == [
+        (
+            "specification-coverage-artifact-execution",
+            "artifact 'artifact' failed its production boundary: seeded replay failure",
+            "input.yaml",
+        )
+    ]

--- a/specs/formal/experiment-core/README.md
+++ b/specs/formal/experiment-core/README.md
@@ -634,3 +634,80 @@ base. The most load-bearing criteria are:
   retention storage, or query services.
 - Orchestration or execution of authored experiment specifications, or
   producing archival run/study records from an `experiment-authoring-input-v1`.
+
+## Partial realization descriptions
+
+`experiment-evidence-record-v1` and realized-form disclosures in
+`experiment-run-v1` MAY carry `typed_description`. Its embedded
+`realization-description/v1` revision describes facts; it is not a new capture
+specification or authoring root. Omission preserves the existing contract.
+Consumers that do not support the embedded revision MUST reject it rather than
+silently replacing its meaning with a summary string.
+
+The description MUST bind the original authored reference by identity, version
+and digest. Each fact has an explicit semantic pointer, stable fact identity,
+knowledge state, and optional recursive value. Source identity/version, time,
+window and actual basis are inherited from description provenance unless the
+fact overrides them. Operation, configuration and evidence references retain
+their existing reference contracts. Backend selection is distinct from observed
+or independently verified evidence; observed bases require evidence references.
+
+Known values reuse the literal, record, keyed-collection and sequence structures
+from recursive realization constraints. Their role is descriptive: every node
+has an explicit backend or observation origin, neutral presence/cardinality,
+and undefined author closure. No authoring or deployment defaults fill missing
+fields. Known null, false, zero, empty text and empty collections remain values.
+Not observed, known absent, withheld, contradictory and not applicable are
+separate states without values. Keyed members MUST agree with their semantic
+identity fields. Ordered sequences retain order and duplicates.
+
+Coverage names its field or collection universe, profile, subject, subset of
+fact identities, completeness and limitations. Recursive coverage is explicit.
+Partial coverage does not close a collection, establish global machine
+completeness, or prove absence outside its scope. Incompatible assertions retain
+their individual identities and provenance. Equal subject/time/window and
+execution/configuration bindings permit conflict detection; different windows
+require explicit reconciliation and are not automatically contradictions.
+
+Private detail reuses exact domain-profile coordinates and descriptive bindings.
+Offline profile admission uses the existing namespace trust, local definitions,
+operation support and explicit opaque-exchange policy. Opaque carriage is not
+comparison or promotion support. Descriptive schema validity is not proof of
+successful realization, required emitted capture, or independent verification.
+The existing capture-offer and content-backed evidence validators remain binding.
+
+Typed detail follows the same demand selectors, protection callbacks, retention
+decision and terminal operation transaction as other descriptions. Producers
+receive the selected scope before acquisition. Retention-disabled reports MUST
+NOT enter durable results and recovery MUST NOT reacquire them. No experimental
+demand creates no experimental collection, regardless of author detail. Export
+and required observation with mutation remain unsupported where their existing
+delivery or compensation owner is unavailable. RAE supplies these semantics and
+conformance boundaries; concrete collection and realization remain backend work.
+
+Profile bindings in a typed description MUST name their enclosing fact's
+semantic subtree and the actual lifecycle carrier. Evidence-record bindings
+use owner `experiment-evidence-record-v1` and phase `capture`; realized-form
+bindings use owner `experiment-run-v1` and phase `realization-description`.
+Nested bindings MUST retain the carrier and remain within their parent's scope.
+Their provenance MUST agree with the fact's achieved basis. Observed profile
+reference IDs MUST join the fact's evidence references and the evidence
+reference accepted by the outer report verifier.
+
+The reference reporting API's evidence identifier denotes an unqualified
+`evidence-record` reference. Every effective retained fact and coverage
+provenance MUST match that complete identity: kind and ID agree, and version,
+digest and path are absent. Matching only the ID MUST NOT authorize additional
+qualifiers or differently qualified references sharing that ID. Profile
+provenance IDs resolve through the same boundary. A fact or coverage override
+replaces the default provenance for that claim; the default participates in
+verification only where a retained claim inherits it.
+
+A protection callback MUST preserve the typed description carrier. The protected
+value is admitted and projected again before reporting or retention. Complete
+coverage MUST match the requested scope, field/collection kind and coverage
+profile, respect exclusions, and cover all requested facts with a compatible
+window and basis. A required exhaustive description without this coverage fails;
+an optional one emits no successful description. Partial descriptions remain
+available for selected demand. A narrow report MUST NOT retain a complete claim
+for a broader scope.

--- a/specs/sdl/recursive-realization-constraints.md
+++ b/specs/sdl/recursive-realization-constraints.md
@@ -168,3 +168,37 @@ deliver a backend witness (#1204). It does not migrate the public software
 authoring surface (#1205), define realization reporting (#1209), negotiate all
 legacy compatibility boundaries (#1210), supply integrated conformance (#1211),
 or select observation, retention and export demand (#1212).
+
+## Descriptive projection and explicit promotion
+
+The experiment lifecycle's `typed_description` uses recursive values without
+granting them author authority. Coverage-aware assessment MUST retain the existing
+conformant, nonconformant, unresolved, invalid, unsupported and limit-exceeded
+outcomes. A supplied scalar or positive absence can contradict an explicit
+constraint. Missing fields in a partial report cannot prove violation or
+satisfaction. A whole-description conformance claim requires complete recursive
+coverage of the same named universe/profile, compatible windows and no unresolved
+facts or limitations before invoking the existing realization evaluator.
+
+Promotion is a pure operation that selects known, supported scalar facts by
+identity and creates a new recursive author-constraint artifact. It MUST preserve
+the source capture and original author artifact. The output records selected
+identities and paths, source/target identity/version/digest, actor, decision, time,
+and an artifact transformation report. Only the selected facts gain authority;
+siblings, incidental descendants and collection closure are not promoted.
+The reference operation refuses nonknown, conflicting, private-profile or
+otherwise unsupported selected facts and requires the canonical composition and
+refinement relation to preserve the original constraints. Structured facts must
+be explicitly captured at the scalar paths selected for this operation.
+
+Returning this artifact grants no permission to store it as author intent or
+execute it. Those operations remain subject to their existing author admission
+and semantic validation owners. Task/run/study refinement, realized-source
+provenance and conditional augmentation disclosures remain independent.
+
+Description completeness MUST match the effective root closure's universe and
+profile, including root-local and lexical scope overrides, and the root's
+field/collection kind. Type-sensitive literal comparison distinguishes an
+integer from a floating-point value. Different observation windows prevent a
+whole-state conformance claim, but MUST NOT hide a supplied value that already
+violates an exact author constraint.

--- a/tools/check_specification_coverage.py
+++ b/tools/check_specification_coverage.py
@@ -94,7 +94,7 @@ def load_bundles(
         max_bytes=_MAX_FILE_BYTES,
     )
     current_path = current_release_path(records)
-    if dict(records)[current_path].get("revision") != "7.0.0" or {record.get("revision") for _, record in records} != {
+    if dict(records)[current_path].get("revision") != "8.0.0" or {record.get("revision") for _, record in records} != {
         "1.0.0",
         "1.1.0",
         "2.0.0",
@@ -103,8 +103,9 @@ def load_bundles(
         "5.0.0",
         "6.0.0",
         "7.0.0",
+        "8.0.0",
     }:
-        raise ValueError("coverage evidence requires the explicit current 7.0.0 release and supported history")
+        raise ValueError("coverage evidence requires the explicit current 8.0.0 release and supported history")
     bundles = []
     for manifest_path, manifest in records:
         bundles.append(_load_bundle_record(repo_root, manifest_path, manifest))
@@ -143,7 +144,7 @@ def evaluate(repo_root: Path = REPO_ROOT) -> list[PolicyFailure]:
         return [_failure("specification-coverage-bundle-invalid", str(exc), MANIFEST_PATH)]
     failures: list[PolicyFailure] = []
     for manifest, protocol, snapshot, analysis in bundles:
-        validator = validate_bundle if manifest.get("revision") == "7.0.0" else validate_historical_bundle
+        validator = validate_bundle if manifest.get("revision") == "8.0.0" else validate_historical_bundle
         failures.extend(validator(repo_root, protocol, snapshot, analysis))
     return failures
 

--- a/tools/formal_semantic_validation/_baseline.py
+++ b/tools/formal_semantic_validation/_baseline.py
@@ -100,10 +100,10 @@ def _selected_baseline_manifest(
         )
         != (
             "docs/research/formal-semantic-validation/protocol-v2.json"
-            if baseline.get("release_revision") in {"3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0"}
+            if baseline.get("release_revision") in {"3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0"}
             else "docs/research/formal-semantic-validation/protocol-v1.json",
             "docs/research/formal-semantic-validation/corpus/manifest-v2.json"
-            if baseline.get("release_revision") in {"3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0"}
+            if baseline.get("release_revision") in {"3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0"}
             else "docs/research/formal-semantic-validation/corpus/manifest-v1.json",
         )
     ):

--- a/tools/formal_semantic_validation/_loading.py
+++ b/tools/formal_semantic_validation/_loading.py
@@ -39,6 +39,7 @@ def load_release_bundles(repo_root: Path = REPO_ROOT) -> list[EvidenceRelease]:
         "7.0.0",
         "8.0.0",
         "9.0.0",
+        "10.0.0",
     }:
         raise ValueError("formal evidence requires every supported historical and current release")
     releases: list[EvidenceRelease] = []
@@ -85,6 +86,6 @@ def load_retest_bundle(
     if not releases:
         raise ValueError("the formal semantic-validation index selects no v2 retest release")
     release = max(releases, key=lambda item: revision_key(item.manifest.get("revision")))
-    if release.manifest.get("revision") != "9.0.0" or release.protocol.get("revision") != "2.0.0":
-        raise ValueError("the current formal evidence release must be the explicit 9.0.0 retest")
+    if release.manifest.get("revision") != "10.0.0" or release.protocol.get("revision") != "2.0.0":
+        raise ValueError("the current formal evidence release must be the explicit 10.0.0 retest")
     return release, release.protocol, release.corpus, release.snapshot, release.analysis

--- a/tools/formal_semantic_validation/_releases.py
+++ b/tools/formal_semantic_validation/_releases.py
@@ -153,7 +153,7 @@ def validate_release_bundle(repo_root: Path, release: EvidenceRelease) -> list[P
                 release.corpus,
                 release.snapshot,
                 release.analysis,
-                replay_current=manifest.get("revision") == "9.0.0",
+                replay_current=manifest.get("revision") == "10.0.0",
             )
         )
     else:
@@ -241,15 +241,25 @@ def validate_retest_bundle(
         "6.0.0",
         "7.0.0",
         "8.0.0",
+        "9.0.0",
     }:
         return [
             _failure(
                 "formal-validation-current-replay-required",
-                "only releases 3.0.0 through 8.0.0 can use integrated historical validation",
+                "only releases 3.0.0 through 9.0.0 can use integrated historical validation",
                 snapshot_path,
             )
         ]
-    if release_revision not in {"3.0.0", "4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0"}:
+    if release_revision not in {
+        "3.0.0",
+        "4.0.0",
+        "5.0.0",
+        "6.0.0",
+        "7.0.0",
+        "8.0.0",
+        "9.0.0",
+        "10.0.0",
+    }:
         failures.append(
             _failure(
                 "formal-validation-retest-release",
@@ -266,7 +276,15 @@ def validate_retest_bundle(
             )
         )
 
-    if release_revision in {"4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0"}:
+    if release_revision in {
+        "4.0.0",
+        "5.0.0",
+        "6.0.0",
+        "7.0.0",
+        "8.0.0",
+        "9.0.0",
+        "10.0.0",
+    }:
         _current_retest_source_failures(
             repo_root,
             snapshot,
@@ -292,7 +310,9 @@ def validate_retest_bundle(
         snapshot_path,
     )
     baseline_cases = (
-        cases_by_id if release_revision in {"4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0"} else historical_cases
+        cases_by_id
+        if release_revision in {"4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0", "10.0.0"}
+        else historical_cases
     )
     _validate_baseline_drift(repo_root, snapshot, baseline_cases, failures, snapshot_path)
     _validate_analysis(repo_root, protocol, corpus, snapshot, analysis, failures, analysis_path)
@@ -326,6 +346,7 @@ def _current_retest_source_failures(
         "7.0.0": "6.0.0",
         "8.0.0": "7.0.0",
         "9.0.0": "8.0.0",
+        "10.0.0": "9.0.0",
     }[release_revision]
     if not isinstance(baseline, Mapping) or baseline.get("release_revision") != expected_baseline:
         failures.append(

--- a/tools/formal_semantic_validation/_retest.py
+++ b/tools/formal_semantic_validation/_retest.py
@@ -67,7 +67,7 @@ def _validate_retest_snapshot(
         _SNAPSHOT_V2_KEYS
         | (
             {"source_state"}
-            if release.manifest.get("revision") in {"4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0"}
+            if release.manifest.get("revision") in {"4.0.0", "5.0.0", "6.0.0", "7.0.0", "8.0.0", "9.0.0", "10.0.0"}
             else set()
         ),
         rule_id="formal-validation-snapshot-shape",
@@ -93,6 +93,7 @@ def _validate_retest_snapshot(
         "7.0.0",
         "8.0.0",
         "9.0.0",
+        "10.0.0",
     }:
         expected_release_paths.update(_retained_fixture_paths(cases_by_id))
     _validate_release_selection(scope, command_ids, expected_release_paths, failures, path)

--- a/tools/policy/requirement_order.yaml
+++ b/tools/policy/requirement_order.yaml
@@ -217,6 +217,21 @@ ownership:
     - CHANGELOG.md
   semantics-expansion:
     - contracts/schemas/sdl
+    # Shared description semantics and existing evidence lifecycle owners (SEM-218).
+    - contracts/schemas/experiment-core/experiment-evidence-record-v1.json
+    - contracts/schemas/experiment-core/experiment-run-v1.json
+    - contracts/schema-publication/entries/experiment-evidence-record-v1.json
+    - contracts/schema-publication/entries/experiment-run-v1.json
+    - contracts/fixtures/experiment-core/experiment-evidence-record-v1
+    - implementations/python/packages/raes_contracts
+    - implementations/python/packages/raes_runtime/observation_execution.py
+    - implementations/python/packages/raes_runtime/observation_results.py
+    - docs/requirements/SEM-218
+    - docs/research/specification-coverage
+    - docs/research/formal-semantic-validation
+    - docs/decisions/issue-1209-clause-mapping.md
+    - docs/decisions/issue-1209-partial-capture-descriptions-preflight.md
+    - specs/sdl/recursive-realization-constraints.md
     - docs/explain/reference
     - implementations/python/packages/raes_processor
     - implementations/python/packages/raes

--- a/tools/specification_coverage/_baseline.py
+++ b/tools/specification_coverage/_baseline.py
@@ -32,7 +32,7 @@ def _baseline_snapshot(repo_root: Path, baseline: object) -> dict[str, object]:
 
 def validate_current_deviations(repo_root: Path, snapshot: dict[str, object]) -> list[PolicyFailure]:
     """Retain every artifact and require an exact disposition for each changed pin."""
-    path = "docs/research/specification-coverage/execution-snapshot-v7.json"
+    path = "docs/research/specification-coverage/execution-snapshot-v8.json"
     try:
         baseline = _baseline_snapshot(repo_root, snapshot.get("baseline"))
         old = {item["path"]: item for item in baseline["artifacts"]}

--- a/tools/specification_coverage/_keys.py
+++ b/tools/specification_coverage/_keys.py
@@ -25,7 +25,7 @@ IMPLEMENTATION_SURFACE_PATHS = {
     "sdl-pipeline": "implementations/python/packages/raes",
 }
 _PACKAGES_ROOT = "implementations/python/packages/"
-_EXECUTION_SNAPSHOT_PATH = "docs/research/specification-coverage/execution-snapshot-v7.json"
+_EXECUTION_SNAPSHOT_PATH = "docs/research/specification-coverage/execution-snapshot-v8.json"
 HISTORICAL_IMPLEMENTATION_SURFACE_PATHS = {
     "contract-models": _PACKAGES_ROOT + "a" + "ces_contracts",
     "processor-pipeline": _PACKAGES_ROOT + "a" + "ces_processor",


### PR DESCRIPTION
## Summary

Partial realization reports need to preserve what is known without filling deployment defaults or changing author intent. Add typed descriptive facts, coverage and provenance to the existing evidence and run disclosures, with conservative comparison and explicit selected-fact promotion.

## Requirement UIDs

- `SEM-218`

## Related Issues

Refs #1209

## ADR Impact

- No ADR required

## Changes

- Add bounded partial-description contracts and publish matching evidence/run schemas and fixtures.
- Reuse observation selection, protection, retention and recovery; verify effective provenance and complete evidence-reference identity.
- Document domain ownership and conformance rules, and refresh source-bound research captures with independent integrity regressions.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Full completion and repository-policy checks passed. Both pre-push reviews ran; all reported findings were repaired and verified. Backend implementations and scenario content remain with their downstream owners.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: SEM-218 ← implementations/python/packages/raes_contracts/contracts/realization_descriptions.py, SEM-218 ← implementations/python/packages/raes_contracts/description_projection.py, SEM-218 ← implementations/python/packages/raes_contracts/description_promotion.py
- TESTS: SEM-218 ← implementations/python/tests/test_issue_1209_descriptions.py, SEM-218 ← implementations/python/tests/test_issue_1209_description_lifecycle.py, SEM-218 ← implementations/python/tests/test_issue_1209_description_evidence.py

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.

## Plain-language summary

- **Context:** Realization reports may know only part of a selected environment.
- **Problem:** Untyped summaries cannot preserve missing knowledge, coverage, and provenance for comparison with author intent.
- **Fix:** Add shared typed descriptions and conformance operations to existing lifecycle contracts; downstream owners continue to supply backend behavior and scenario content.

## Verification

Full completion, repository policy, pre-commit, and merged-tree verification passed. Both required reviews ran and their findings were repaired with regression evidence.

## Issue tracking

Closes #1209

