### PR TITLE
fix(release): keep release bookkeeping from failing verification or re-running checks

### DIFF
--- a/.github/workflows/bootstrap-qualification.yml
+++ b/.github/workflows/bootstrap-qualification.yml
@@ -1,8 +1,14 @@
 name: Bootstrap qualification
 
+# The main->dev back-merge PR changes only Release Please-managed files, which
+# were qualified on the dev->main promotion; it does not trigger this (#1266).
 on:
   pull_request:
     branches: [dev]
+    paths-ignore:
+      - CHANGELOG.md
+      - .release-please-manifest.json
+      - implementations/python/packages/raes/_version.py
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,25 @@
 name: CI
 
+# Release Please bookkeeping (the release PR, the main->dev back-merge PR, and
+# their merge pushes) changes only the release-managed files below. Every check
+# already ran on the dev->main promotion, and release-please.yml re-runs the
+# canonical verifier on the exact release SHA before publishing, so those events
+# do not trigger this workflow. The list is kept identical across workflows and
+# equal to the files Release Please manages (#1266).
 on:
   push:
     branches: [main, dev]
     tags: ["v*"]
+    paths-ignore:
+      - CHANGELOG.md
+      - .release-please-manifest.json
+      - implementations/python/packages/raes/_version.py
   pull_request:
     branches: [main, dev]
+    paths-ignore:
+      - CHANGELOG.md
+      - .release-please-manifest.json
+      - implementations/python/packages/raes/_version.py
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,12 +2,21 @@ name: Docs
 
 # Validate the curated public docs on pull requests and publish that same output
 # to GitHub Pages from main.
+#
+# Pull requests that change only Release Please-managed files (the release PR
+# and the main->dev back-merge PR) do not rebuild the docs (#1266). The push to
+# main is not filtered: the published docs render the release version, so the
+# release commit must still redeploy them.
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main, dev]
+    paths-ignore:
+      - CHANGELOG.md
+      - .release-please-manifest.json
+      - implementations/python/packages/raes/_version.py
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/post-merge-closing-issue-audit.yml
+++ b/.github/workflows/post-merge-closing-issue-audit.yml
@@ -1,9 +1,15 @@
 name: Post-merge Closing Issue Audit
 
+# The main->dev back-merge PR changes only Release Please-managed files and
+# closes no issues, so it is not audited (#1266).
 on:
   pull_request:
     types: [closed]
     branches: [dev]
+    paths-ignore:
+      - CHANGELOG.md
+      - .release-please-manifest.json
+      - implementations/python/packages/raes/_version.py
 
 permissions:
   contents: read

--- a/.github/workflows/pr-body-policy.yml
+++ b/.github/workflows/pr-body-policy.yml
@@ -1,9 +1,15 @@
 name: PR Body Policy
 
+# The bot-authored main->dev back-merge PR changes only Release Please-managed
+# files and is not subject to the human PR body policy (#1266).
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: [dev]
+    paths-ignore:
+      - CHANGELOG.md
+      - .release-please-manifest.json
+      - implementations/python/packages/raes/_version.py
 
 permissions:
   contents: read

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -12,11 +12,17 @@ name: PR Title Lint
 # Scoped to PRs targeting `dev` (feature PRs). On a squash-merged feature PR the
 # conventional title becomes the commit release-please reads, so it is enforced
 # there. `dev`->`main` promotion PRs are not squashed and their title never
-# becomes a release commit, so linting them is noise (#684).
+# becomes a release commit, so linting them is noise (#684). The bot-authored
+# main->dev back-merge PR changes only Release Please-managed files and is
+# likewise not linted (#1266).
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: [dev]
+    paths-ignore:
+      - CHANGELOG.md
+      - .release-please-manifest.json
+      - implementations/python/packages/raes/_version.py
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,9 +14,11 @@ name: Release Please
 # collisions. The version literal is in the dedicated RAES package version file;
 # `raes.__version__` derives from the installed distribution metadata.
 #
-# Caveat: the release PR is opened by GITHUB_TOKEN, so required CI checks do not
-# auto-run on it. Exact-SHA verification below is therefore the non-bypassable
-# publication gate even when a maintainer admin-merges that PR.
+# The release PR, the main->dev back-merge PR, and their merge pushes change only
+# Release Please-managed files, so check workflows deliberately do not trigger on
+# them (#1266): everything they would check already passed on the dev->main
+# promotion. Exact-SHA verification below is the non-bypassable publication gate
+# for the release commit, and a maintainer admin-merges the release PR.
 # First release + PyPI setup: docs/explain/releasing.md.
 on:
   push:
@@ -751,8 +753,9 @@ jobs:
   # After a release is cut, the version bump + CHANGELOG land on `main`, so `dev`
   # falls one release commit behind. Open a back-merge PR so `dev` is resynced.
   # `main` is ahead of `dev` only by the release commit (a fast-forward). This
-  # job cannot auto-merge it: `dev` requires status checks that a bot-opened PR
-  # does not trigger, and repo auto-merge is off — merge it yourself (admin
+  # job cannot auto-merge it: the PR changes only Release Please-managed files,
+  # so `dev`'s check workflows do not trigger on it (#1266) and its required
+  # checks never report, and repo auto-merge is off — merge it yourself (admin
   # override; enforce_admins is false).
   sync-dev:
     needs: [release-please, publish-github]
@@ -782,4 +785,4 @@ jobs:
           fi
           gh pr create --repo "${GITHUB_REPOSITORY}" --base dev --head main \
             --title "chore: back-merge ${TAG} into dev" \
-            --body "Automated back-merge of the ${TAG} release commit (version bump + CHANGELOG) from \`main\` into \`dev\`, so \`dev\` stays in sync. \`main\` is ahead of \`dev\` only by the release commit (fast-forward). \`dev\`'s required checks do not run on this bot-opened PR — merge it directly (admin)."
+            --body "Automated back-merge of the ${TAG} release commit (version bump + CHANGELOG) from \`main\` into \`dev\`, so \`dev\` stays in sync. \`main\` is ahead of \`dev\` only by the release commit (fast-forward). It changes only Release Please-managed files, so \`dev\`'s check workflows do not trigger on it — merge it directly (admin)."

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,11 +1,18 @@
 name: OpenSSF Scorecard
 
+# A release commit changes only Release Please-managed files and cannot change
+# the repository's security posture, so its push to main does not re-score
+# (#1266). Promotions, protection changes, and the weekly schedule still do.
 on:
   branch_protection_rule:
   schedule:
     - cron: "17 3 * * 1"
   push:
     branches: [main]
+    paths-ignore:
+      - CHANGELOG.md
+      - .release-please-manifest.json
+      - implementations/python/packages/raes/_version.py
 
 permissions: {}
 

--- a/docs/explain/releasing.md
+++ b/docs/explain/releasing.md
@@ -89,16 +89,30 @@ Use `feat:`/`fix:` for consumer-visible changes so release-please cuts a release
 - `release-please-config.json` creates releases as drafts and forces the tag to
   exist immediately. Only the gated GitHub publication job removes draft state.
 
-## Caveat: the release PR and required checks
+## Release bookkeeping does not re-run checks
 
-The release PR is opened by `GITHUB_TOKEN`, so **required status checks do not
-auto-run on the PR** (GitHub's recursion guard). Two review options remain:
+The release PR, the `main` → `dev` back-merge PR opened by the `sync-dev` job,
+and the pushes that merging them produces change only the files Release Please
+manages: `CHANGELOG.md`, `.release-please-manifest.json`, and
+`implementations/python/packages/raes/_version.py`. Every check already ran on
+the `dev` → `main` promotion, so the check workflows list exactly those files
+under `paths-ignore` and do not trigger on these events (#1266). The Docs
+deployment on the `main` push is not filtered, because the published docs
+render the release version. `test_release_workflows.py` keeps the ignored set
+identical across workflows and equal to the Release Please configuration.
 
-- **Admin-merge** the release PR (bypass the required checks for that PR), or
-- Give release-please a **PAT** (repo `contents`+`pull_requests`) as the `token`
-  input so its PRs trigger checks normally.
+Because the check workflows do not trigger, the required status checks never
+report on either bot PR. **Admin-merge** both. Adding any other change to
+either PR brings the full check suite back.
 
-Neither option can bypass publication verification. After the release PR lands,
+Research evidence captures bind a digest of the reference-package sources
+(source profile `python-reference-source/v2`). That digest replaces the marked
+Release Please version literal with a placeholder, so the release commit's
+version bump cannot invalidate the evidence. Any other change to `_version.py`
+still changes the digest, and a version file without exactly one marked literal
+fails closed.
+
+Skipping checks cannot bypass publication verification. After the release PR lands,
 the release workflow keeps the GitHub Release private as a draft while it runs
 the canonical graph against the exact tagged commit. PyPI upload,
 GitHub artifact attachment, and public Release finalization depend directly on

--- a/docs/research/formal-semantic-validation/bundles/retest-v8.json
+++ b/docs/research/formal-semantic-validation/bundles/retest-v8.json
@@ -118,5 +118,5 @@
   "protocol_sha256": "abf94093e344bf495dfb04e8b0c5985c0beaab8ebb17a75e15c8674fa81b1a7c",
   "revision": "9.0.0",
   "snapshot_path": "docs/research/formal-semantic-validation/execution-snapshot-v8.json",
-  "snapshot_sha256": "29bab7d876143153f2652c5d702bad34fddc3f5d63b95fe482c1365a34c177f3"
+  "snapshot_sha256": "10fd6cf2cfc63107e8424e9a1048130eb4e7239d11021113d5291c2bc4b81530"
 }

--- a/docs/research/formal-semantic-validation/execution-snapshot-v8.json
+++ b/docs/research/formal-semantic-validation/execution-snapshot-v8.json
@@ -645,8 +645,8 @@
   "source_state": {
     "base_revision": "9b69eb211afd0785809fc9db053f5799dc36eae9",
     "checkout_state": "modified",
-    "implementation_digest": "b47bceb748a1450d1532d547d73e6f427ed17c8d4319f1871666419731a0a55d",
-    "profile": "python-reference-source/v1"
+    "implementation_digest": "df21073ba069a1c6f9efd2e437ff571b62b04e659b0b57dbc349e3b16a642e5f",
+    "profile": "python-reference-source/v2"
   },
   "versions": {
     "python": "3.13.13",

--- a/docs/research/formal-semantic-validation/index.md
+++ b/docs/research/formal-semantic-validation/index.md
@@ -135,8 +135,11 @@ code. Only the current release supports a current-code claim.
 
 The current capture's `source_state` records a base Git commit, the modified
 checkout state, and a deterministic digest of all reference-package Python
-sources plus `pyproject.toml` and `uv.lock`. The base commit is not represented
-as the exact clean capture revision. Validation recomputes the implementation
+sources plus `pyproject.toml` and `uv.lock`. Source profile
+`python-reference-source/v2` binds the Release Please version literal in
+`raes/_version.py` as a placeholder, so a release version bump does not change
+the digest; `v1` captures remain valid only as historical records. The base
+commit is not represented as the exact clean capture revision. Validation recomputes the implementation
 digest. A changed implementation requires a new explicitly supported release,
 not rewriting history or extending a digest allowlist. Classification migration
 is not a claim class in the retained preregistration and is not promoted to

--- a/docs/research/specification-coverage/analysis-v7.json
+++ b/docs/research/specification-coverage/analysis-v7.json
@@ -84,5 +84,5 @@
     }
   ],
   "snapshot_id": "raes-standardized-specification-coverage-issue-1204-v7",
-  "snapshot_sha256": "a3f51cef9485c365dc89f96caf87e3d41b76f1443c070efbbf96d5926e311172"
+  "snapshot_sha256": "0a80fa4a2d08c2315f8abf4cc4f9164a10815108db4292de32aa09622d757a70"
 }

--- a/docs/research/specification-coverage/bundles/raes-standardized-specification-coverage-issue-1204-v7.json
+++ b/docs/research/specification-coverage/bundles/raes-standardized-specification-coverage-issue-1204-v7.json
@@ -1,10 +1,10 @@
 {
   "analysis_path": "docs/research/specification-coverage/analysis-v7.json",
-  "analysis_sha256": "87feba6dc59984f020e7d41298beaec0585efd3c2748670f6632f2ca4c72bfed",
+  "analysis_sha256": "10c17e895593d990c6bc42d4a0b93e59f8096b0b4197cedee2c439baa8d1a2bf",
   "bundle_id": "raes-standardized-specification-coverage",
   "protocol_path": "docs/research/specification-coverage/protocol-v1.json",
   "protocol_sha256": "e97a19e643e94c9e589dca823a63c6ce49d3329fe2a3cb888ab630838ed93125",
   "revision": "7.0.0",
   "snapshot_path": "docs/research/specification-coverage/execution-snapshot-v7.json",
-  "snapshot_sha256": "9e7c670b9b484093bbe0554543bf6be0df00e7195510ca5bb6016eb4a2108305"
+  "snapshot_sha256": "5b0b15d838c1187b875d2a8b1def5c10ed0cd45fe5261593fef227718a7dc7b7"
 }

--- a/docs/research/specification-coverage/execution-snapshot-v7.json
+++ b/docs/research/specification-coverage/execution-snapshot-v7.json
@@ -651,7 +651,7 @@
       "surface_id": "processor-pipeline"
     },
     {
-      "content_sha256": "06bb7e348db6e9409a668ea4a9ca846cee8bde4f93913399d7310aa4aaf67ce8",
+      "content_sha256": "3600e218c39efada230698eb9bae5047db4ffd6de62668ba84e5e61ab901ae66",
       "path": "implementations/python/packages/raes",
       "surface_id": "sdl-pipeline"
     }
@@ -671,7 +671,7 @@
   "source_state": {
     "base_revision": "9b69eb211afd0785809fc9db053f5799dc36eae9",
     "checkout_state": "modified",
-    "implementation_digest": "b47bceb748a1450d1532d547d73e6f427ed17c8d4319f1871666419731a0a55d",
-    "profile": "python-reference-source/v1"
+    "implementation_digest": "df21073ba069a1c6f9efd2e437ff571b62b04e659b0b57dbc349e3b16a642e5f",
+    "profile": "python-reference-source/v2"
   }
 }

--- a/implementations/python/tests/test_issue_989_versioned_evidence.py
+++ b/implementations/python/tests/test_issue_989_versioned_evidence.py
@@ -1,5 +1,6 @@
 """Behavioral regressions for current replay and historical evidence retention."""
 
+import re
 from copy import deepcopy
 from pathlib import Path
 
@@ -342,3 +343,95 @@ def test_classification_retirement_has_a_recorded_adr_001_amendment():
     assert "#989" in amendment_refs(content)
     assert "#989" in {item["ref"] for item in entry["amendments"]}
     assert entry["pin"] == hashlib.sha256(canonical_content(content).encode()).hexdigest()
+
+
+def _release_managed_source_tree(tmp_path: Path, version_source: str) -> Path:
+    from tools.research_evidence import RELEASE_MANAGED_VERSION_SOURCE
+
+    python = tmp_path / "implementations/python"
+    (python / "packages/raes").mkdir(parents=True)
+    (python / "pyproject.toml").write_text('[project]\nname = "raes"\n', encoding="utf-8")
+    (python / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    (python / "packages/raes/__init__.py").write_text("from raes._version import __version__\n", encoding="utf-8")
+    (tmp_path / RELEASE_MANAGED_VERSION_SOURCE).write_text(version_source, encoding="utf-8")
+    return tmp_path
+
+
+def _released_version_source(version: str) -> str:
+    from tools.research_evidence import RELEASE_MANAGED_VERSION_SOURCE
+
+    current = (ROOT / RELEASE_MANAGED_VERSION_SOURCE).read_text(encoding="utf-8")
+    released, count = re.subn(r'(__version__ = ")[^"]+(")', rf"\g<1>{version}\g<2>", current)
+    assert count == 1
+    return released
+
+
+def _source_digests(root: Path) -> tuple[str, str]:
+    from tools.research_evidence import implementation_digest, surface_digest
+
+    return implementation_digest(root), surface_digest(root, "implementations/python/packages/raes")
+
+
+def test_release_version_bump_does_not_change_source_identity(tmp_path):
+    before = _source_digests(_release_managed_source_tree(tmp_path / "before", _released_version_source("3.5.0")))
+    after = _source_digests(_release_managed_source_tree(tmp_path / "after", _released_version_source("4.0.0")))
+
+    assert before == after
+
+
+def test_release_managed_source_still_binds_everything_but_the_version_literal(tmp_path):
+    released = _released_version_source("4.0.0")
+    baseline = _source_digests(_release_managed_source_tree(tmp_path / "baseline", released))
+    changed = _source_digests(_release_managed_source_tree(tmp_path / "changed", released + "RELEASE_HOOK = True\n"))
+
+    assert baseline[0] != changed[0]
+    assert baseline[1] != changed[1]
+
+
+@pytest.mark.parametrize(
+    "version_source",
+    [
+        '__version__ = "4.0.0"\n',
+        '__version__ = "4.0.0"  # x-release-please-version\nOTHER = "1.0.0"  # x-release-please-version\n',
+        '__version__ = __import__("os").getenv("V")  # x-release-please-version\n',
+    ],
+)
+def test_malformed_release_managed_source_fails_closed(tmp_path, version_source):
+    from tools.research_evidence import implementation_digest, source_state_failures, surface_digest
+
+    root = _release_managed_source_tree(tmp_path, version_source)
+    with pytest.raises(ValueError, match="release-managed version source"):
+        implementation_digest(root)
+    with pytest.raises(ValueError, match="release-managed version source"):
+        surface_digest(root, "implementations/python/packages/raes")
+    state = {
+        "profile": "python-reference-source/v2",
+        "base_revision": "0" * 40,
+        "checkout_state": "clean",
+        "implementation_digest": "0" * 64,
+    }
+    assert source_state_failures(root, state, "capture.json", current=True)
+
+
+def test_release_managed_version_source_is_the_file_release_please_rewrites():
+    import json
+
+    from tools.research_evidence import RELEASE_MANAGED_VERSION_SOURCE
+
+    config = json.loads((ROOT / "release-please-config.json").read_text(encoding="utf-8"))
+    extra_files = config["packages"]["."]["extra-files"]
+    assert extra_files == [{"type": "generic", "path": RELEASE_MANAGED_VERSION_SOURCE}]
+
+
+def test_current_capture_requires_the_release_stable_source_profile():
+    from tools.formal_semantic_validation._loading import load_retest_bundle
+    from tools.research_evidence import SOURCE_PROFILE, source_state_failures
+
+    _, _, _, snapshot, _ = load_retest_bundle(ROOT)
+    state = deepcopy(snapshot["source_state"])
+    assert state["profile"] == SOURCE_PROFILE == "python-reference-source/v2"
+    assert source_state_failures(ROOT, state, "capture.json", current=True) == []
+
+    state["profile"] = "python-reference-source/v1"
+    assert source_state_failures(ROOT, state, "capture.json", current=True)
+    assert source_state_failures(ROOT, state, "capture.json", current=False) == []

--- a/implementations/python/tests/test_public_project_readiness.py
+++ b/implementations/python/tests/test_public_project_readiness.py
@@ -22,7 +22,17 @@ def test_scorecard_workflow_is_pinned_least_privilege_and_publishes_sarif() -> N
     assert "pull_request_target" not in triggers
     assert "workflow_dispatch" not in triggers
     assert triggers["schedule"] == [{"cron": "17 3 * * 1"}]
-    assert triggers["push"] == {"branches": ["main"]}
+    # A release commit only touches Release Please-managed files (#1266); the set
+    # is kept identical across workflows by test_release_workflows.py.
+    assert triggers["push"] == {
+        "branches": ["main"],
+        "paths-ignore": [
+            "CHANGELOG.md",
+            ".release-please-manifest.json",
+            "implementations/python/packages/raes/_version.py",
+        ],
+    }
+    assert triggers["branch_protection_rule"] is None
     analysis = workflow["jobs"]["analysis"]
     assert analysis["runs-on"] == "ubuntu-24.04"
     assert analysis["permissions"] == {

--- a/implementations/python/tests/test_release_workflows.py
+++ b/implementations/python/tests/test_release_workflows.py
@@ -680,3 +680,58 @@ def test_publishing_workflows_pin_every_third_party_action_to_a_full_sha() -> No
             if action_ref.startswith("./"):
                 continue
             assert FULL_SHA_USE.fullmatch(action_ref), f"{path.name}: unpinned action {action_ref!r}"
+
+
+def _release_managed_paths() -> list[str]:
+    package = _load(RELEASE_CONFIG_PATH)["packages"]["."]
+    (release_please,) = [
+        step for step in _load(RELEASE_PATH)["jobs"]["release-please"]["steps"] if step.get("id") == "rp"
+    ]
+    manifest = release_please["with"]["manifest-file"]
+    return sorted([package["changelog-path"], manifest, *(item["path"] for item in package["extra-files"])])
+
+
+# Events that must still run when only release-managed files change: Release
+# Please itself publishes, and the main Docs push redeploys the release version.
+_RELEASE_BOOKKEEPING_RUNS = {("release-please.yml", "push"), ("docs.yml", "push")}
+
+
+def test_release_bookkeeping_changes_do_not_retrigger_check_workflows() -> None:
+    expected = _release_managed_paths()
+    assert expected == [
+        ".release-please-manifest.json",
+        "CHANGELOG.md",
+        "implementations/python/packages/raes/_version.py",
+    ]
+
+    filtered: set[tuple[str, str]] = set()
+    unfiltered: set[tuple[str, str]] = set()
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        triggers = _load(path)["on"]
+        if isinstance(triggers, str):
+            triggers = {triggers: None}
+        elif isinstance(triggers, list):
+            triggers = dict.fromkeys(triggers)
+        for event in ("push", "pull_request"):
+            if event not in triggers:
+                continue
+            config = triggers[event] or {}
+            assert "paths" not in config, f"{path.name} {event}: positive path filters would hide real changes"
+            if "paths-ignore" in config:
+                assert sorted(config["paths-ignore"]) == expected, f"{path.name} {event}: ignored paths drifted"
+                assert len(config["paths-ignore"]) == len(set(config["paths-ignore"]))
+                filtered.add((path.name, event))
+            else:
+                unfiltered.add((path.name, event))
+
+    assert unfiltered == _RELEASE_BOOKKEEPING_RUNS
+    assert filtered == {
+        ("bootstrap-qualification.yml", "pull_request"),
+        ("ci.yml", "pull_request"),
+        ("ci.yml", "push"),
+        ("docs.yml", "pull_request"),
+        ("post-merge-closing-issue-audit.yml", "pull_request"),
+        ("pr-body-policy.yml", "pull_request"),
+        ("pr-title-lint.yml", "pull_request"),
+        ("scorecard.yml", "push"),
+    }

--- a/tools/research_evidence.py
+++ b/tools/research_evidence.py
@@ -11,7 +11,17 @@ from pathlib import Path
 from tools.evidence_bundle_index import revision_key
 from tools.policy.common import PolicyFailure, safe_repo_path
 
-SOURCE_PROFILE = "python-reference-source/v1"
+# v2 binds the Release Please version literal as a placeholder, so a release
+# commit does not change the identity of the source it releases. v1 captures
+# hashed the literal and stay valid only as historical records.
+SOURCE_PROFILE = "python-reference-source/v2"
+HISTORICAL_SOURCE_PROFILES = frozenset({"python-reference-source/v1", SOURCE_PROFILE})
+RELEASE_MANAGED_VERSION_SOURCE = "implementations/python/packages/raes/_version.py"
+_RELEASE_VERSION_MARKER = "x-release-please-version"
+_RELEASE_VERSION_LINE = re.compile(
+    r'^(__version__ = ")[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?("  # x-release-please-version)$',
+    re.MULTILINE,
+)
 _SOURCE_KEYS = {"profile", "base_revision", "checkout_state", "implementation_digest"}
 
 
@@ -21,6 +31,18 @@ def _source_size(path: Path, total: int) -> int:
     if size > 2 * 1024 * 1024 or total > 128 * 1024 * 1024:
         raise ValueError("implementation source budget exceeded")
     return total
+
+
+def _source_bytes(path: Path, relative: str) -> bytes:
+    """Return the bytes a source pin binds; only the release version literal is abstracted."""
+    content = path.read_bytes()
+    if relative != RELEASE_MANAGED_VERSION_SOURCE:
+        return content
+    text = content.decode("utf-8")
+    normalized, replaced = _RELEASE_VERSION_LINE.subn(r"\g<1>release-managed\g<2>", text)
+    if replaced != 1 or text.count(_RELEASE_VERSION_MARKER) != 1:
+        raise ValueError("release-managed version source must carry exactly one marked version literal")
+    return normalized.encode("utf-8")
 
 
 def surface_digest(repo_root: Path, relative: str) -> str:
@@ -37,7 +59,8 @@ def surface_digest(repo_root: Path, relative: str) -> str:
         total = _source_size(path, total)
         if len(pins) >= 10000:
             raise ValueError("implementation source budget exceeded")
-        pins.append([path.relative_to(root).as_posix(), hashlib.sha256(path.read_bytes()).hexdigest()])
+        source = _source_bytes(path, path.relative_to(repo_root).as_posix())
+        pins.append([path.relative_to(root).as_posix(), hashlib.sha256(source).hexdigest()])
     if not pins:
         raise ValueError("empty implementation surface")
     return hashlib.sha256(json.dumps(pins, separators=(",", ":")).encode()).hexdigest()
@@ -70,16 +93,17 @@ def implementation_digest(repo_root: Path) -> str:
         if resolved is None or not resolved.is_file() or path.is_symlink():
             raise ValueError("unsafe reference implementation source")
         total = _source_size(resolved, total)
-        pins.append([relative, hashlib.sha256(resolved.read_bytes()).hexdigest()])
+        pins.append([relative, hashlib.sha256(_source_bytes(resolved, relative)).hexdigest()])
     encoded = json.dumps(pins, ensure_ascii=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _source_identity_valid(state: object) -> bool:
+def _source_identity_valid(state: object, profiles: frozenset[str]) -> bool:
     return (
         isinstance(state, Mapping)
         and set(state) == _SOURCE_KEYS
-        and state.get("profile") == SOURCE_PROFILE
+        and isinstance(state.get("profile"), str)
+        and state.get("profile") in profiles
         and isinstance(state.get("checkout_state"), str)
         and state.get("checkout_state") in {"clean", "modified"}
         and isinstance(state.get("base_revision"), str)
@@ -91,7 +115,7 @@ def _source_identity_valid(state: object) -> bool:
 
 def source_state_failures(repo_root: Path, state: object, path: str, *, current: bool) -> list[PolicyFailure]:
     """Historical source identity is retained; a current capture binds live code."""
-    valid = _source_identity_valid(state)
+    valid = _source_identity_valid(state, frozenset({SOURCE_PROFILE}) if current else HISTORICAL_SOURCE_PROFILES)
     if valid and current:
         try:
             valid = state["implementation_digest"] == implementation_digest(repo_root)

--- a/tools/research_evidence.py
+++ b/tools/research_evidence.py
@@ -19,8 +19,8 @@ HISTORICAL_SOURCE_PROFILES = frozenset({"python-reference-source/v1", SOURCE_PRO
 RELEASE_MANAGED_VERSION_SOURCE = "implementations/python/packages/raes/_version.py"
 _RELEASE_VERSION_MARKER = "x-release-please-version"
 _RELEASE_VERSION_LINE = re.compile(
-    r'^(__version__ = ")[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?("  # x-release-please-version)$',
-    re.MULTILINE,
+    r'^(__version__ = ")\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?(" {2}# x-release-please-version)$',
+    re.MULTILINE | re.ASCII,
 )
 _SOURCE_KEYS = {"profile", "base_revision", "checkout_state", "implementation_digest"}
 


### PR DESCRIPTION
## Plain-language summary

- **Context:** The v4.0.0 release never reached PyPI. Release Please run [34723582912](https://github.com/OpenRAE/rae/actions/runs/34723582912) failed `verify-release / verify` on the release commit `bfecc2b9`, so every publish job was skipped. Separately, each release re-runs the full check suite on bot PRs and pushes that change only release bookkeeping files.
- **Problem:** The research evidence source identity hashed the Release Please version literal. The release commit changes only `raes/_version.py` (plus `CHANGELOG.md` and the manifest), and that one line changed both the implementation digest and the `sdl-pipeline` surface digest pinned by the current formal-semantic (9.0.0) and specification-coverage (7.0.0) captures. As a result, every release commit fails verification. CI on main before the release (`11bfb2b6`) passed `verify`; the version bump is the whole difference. Meanwhile the release PR, the main→dev back-merge PR, and their merge pushes trigger CI, Docs, bootstrap qualification, PR policy, the issue audit, and Scorecard again. All of those already passed on the dev→main promotion. On the bot PRs the runs are held for approval and expire as failures (CI #1519, Docs #850).
- **Fix:** Source profile `python-reference-source/v2` hashes `raes/_version.py` with its marked version literal replaced by a fixed token, so a release version bump no longer changes the digest. The two current captures and their dependent hashes are re-pinned under v2. Check workflows now `paths-ignore` exactly the three Release Please-managed files, so release bookkeeping no longer triggers them.

### Evidence digest

- `_version.py` still counts toward the digest; only the `__version__ = "X.Y.Z"  # x-release-please-version` literal is abstracted. Any other edit to the file still changes the digest.
- A version file that does not carry exactly one marked literal raises, so the source identity fails closed. This covers a missing marker, a second marker, or a non-literal value.
- Current captures must declare v2. Historical captures keep v1 and are still only shape-checked, never recomputed.
- Re-pinned: `implementation_digest` and `profile` in `execution-snapshot-v8.json` (formal) and `execution-snapshot-v7.json` (coverage); the coverage `sdl-pipeline` `content_sha256`; and the dependent `snapshot_sha256` / `analysis_sha256` in `retest-v8.json`, `analysis-v7.json`, and the v7 coverage bundle. This is the same cascade #1260 used.

### Release bookkeeping triggers

`paths-ignore: [CHANGELOG.md, .release-please-manifest.json, implementations/python/packages/raes/_version.py]` applies to:

| Workflow | Events filtered |
| --- | --- |
| CI | `push`, `pull_request` |
| Docs | `pull_request` |
| Bootstrap qualification | `pull_request` |
| PR Body Policy / PR Title Lint | `pull_request` |
| Post-merge Closing Issue Audit | `pull_request` |
| OpenSSF Scorecard | `push` |

Two events intentionally still run:
- **Release Please on push:** it is the publisher, and it re-runs the canonical verifier on the exact release SHA before anything reaches PyPI.
- **Docs on push to `main`:** the published docs render the release version, so the release commit must redeploy them.

Path filters apply only when **every** changed file is in the list, so any real change brings the full suite back. `test_release_workflows.py` derives the list from `release-please-config.json` and the workflow's `manifest-file`. It fails if any workflow's list drifts, if a positive `paths` filter appears, or if any `push`/`pull_request` trigger other than the two above lacks the filter.

The release and back-merge PRs are still admin-merged, as before: their required checks never report. The workflow comments, the back-merge PR body, and `docs/explain/releasing.md` now say so.

## Issue tracking

Closes #1266

## Verification

- **Release simulation:** in an isolated worktree of this branch with `_version.py` bumped to `4.0.1` and its own `uv sync`ed environment, the four tests that failed in the v4.0.0 release pass. They are `test_atomic_release_index_validates_every_historical_bundle`, `test_current_retest_bundle_is_coherent_and_clean`, `test_current_bundle_is_clean`, and `test_gate_replays_participant_tests_instead_of_trusting_pass_labels`. `tools/check_specification_coverage.py` exits 0, and the full formal, coverage, and versioned-evidence suites pass (143 tests).
- **New tests fail on the old code:** against the previous `tools/research_evidence.py`, the version-bump invariance test, all three fail-closed cases, and the v2-profile requirement fail (5 failed).
- `pytest tests/test_formal_semantic_validation.py tests/test_specification_coverage.py tests/test_issue_989_versioned_evidence.py`: passed.
- `pytest tests/test_release_workflows.py tests/test_public_project_readiness.py`: 18 passed.
- `nox -s lint`: passed.
- `nox -s verify -- --base-rev <origin/dev> --skip-requirement`: passed (unit 8486 passed / 1 skipped; integration 81 passed / 2 skipped; contracts, static, policy, Isabelle proof, and docs lanes passed). The first run caught `test_public_project_readiness.py` still pinning the old Scorecard `push` trigger; that pin now asserts the filtered trigger.

## Notes for review

v4.0.0 (tag and draft Release) points at `bfecc2b9`, which cannot pass verification. It is not re-published by this PR. Once this reaches `main`, the next Release Please release is the first 4.x on PyPI.

CodeQL default setup and GitGuardian are configured outside workflow files, so they still run on the bot PRs.

https://claude.ai/code/session_01E2zNWFWeLt7JSj4n4ubNEC
